### PR TITLE
[Spring 지하철 노선도 - 1,2단계] 오리(최진영) 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,24 @@
-<p align="center">
-    <img width="200px;" src="https://raw.githubusercontent.com/woowacourse/atdd-subway-admin-frontend/master/images/main_logo.png"/>
-</p>
-<p align="center">
-  <a href="https://techcourse.woowahan.com/c/Dr6fhku7" alt="woowacourse subway">
-    <img alt="Website" src="https://img.shields.io/website?url=https%3A%2F%2Fedu.nextstep.camp%2Fc%2FR89PYi5H">
-  </a>
-  <img alt="GitHub" src="https://img.shields.io/github/license/woowacourse/atdd-subway-map">
-</p>
+### 1. 지하철 역 관리 API 기능 완성하기
+- 지하철역 생성 시 이미 등록된 이름으로 요청한다면 에러를 응답
+    - 400 Bad Request
+    - StationService에서 CustomException을 만들면 될 것
+    - Dao에서 존재하는지 확인하는 기능
 
-<br>
+- Dao는 static 메소드로 사용
+- Service를 추가
 
-# 지하철 노선도 미션
-스프링 과정 실습을 위한 지하철 노선도 애플리케이션
 
-<br>
-
-## 🚀 Getting Started
-### Usage
-#### application 구동
-```
-./gradlew bootRun
-```
-<br>
-
-## ✏️ Code Review Process
-[텍스트와 이미지로 살펴보는 온라인 코드 리뷰 과정](https://github.com/next-step/nextstep-docs/tree/master/codereview)
-
-<br>
-
-## 🐞 Bug Report
-
-버그를 발견한다면, [Issues](https://github.com/woowacourse/atdd-subway-map/issues) 에 등록해주세요 :)
-
-<br>
-
-## 📝 License
-
-This project is [MIT](https://github.com/woowacourse/atdd-subway-map/blob/master/LICENSE) licensed.
+- StationDao 기능 추가 및 테스트
+    - save()
+    - findAll()
+    - delete() - 구현 필요
+    - existByName() - 구현 필요
+- StationService 기능 추가 및 테스트
+    - save()
+        - 중복 시 예외 발생 기능 추가
+        - station 저장 기능 추가
+    - findAll()
+    - delete()
+- StationController 수정 사항
+    - Service 로직 적용
+    - Dto 정적 팩토리 메소드 수정

--- a/README.md
+++ b/README.md
@@ -22,3 +22,20 @@
 - StationController 수정 사항
     - Service 로직 적용
     - Dto 정적 팩토리 메소드 수정
+
+### 2. 지하철 노선 관리 API 구현하기 + e2e 테스트
+- 등록(POST) 200 ok
+  `/lines`
+  [ERROR] 같은 이름의 노선이 생성될 경우 예외 발생
+
+- 전체 목록(GET) 200 ok
+  `/lines`
+
+- 단일 조회(GET) 200 ok
+  `/lines/{lineId}`
+
+- 수정(PUT) 200 ok
+  `/lines/{lineId}`
+
+- 삭제(DELETE) 204 no content
+  `/lines/{lineId}`

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// log
-//	implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
+	implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
 
 	testImplementation 'io.rest-assured:rest-assured:4.4.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,10 @@ dependencies {
 	// spring
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// log
-	implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
+//	implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
 
 	testImplementation 'io.rest-assured:rest-assured:4.4.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/wooteco/subway/dao/InmemoryLineDao.java
+++ b/src/main/java/wooteco/subway/dao/InmemoryLineDao.java
@@ -1,0 +1,74 @@
+package wooteco.subway.dao;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.util.ReflectionUtils;
+import wooteco.subway.domain.Line;
+
+public class InmemoryLineDao implements LineDao {
+
+    private static InmemoryLineDao INSTANCE;
+
+    private Long seq = 0L;
+    private final Map<Long, Line> lines = new HashMap<>();
+
+    private InmemoryLineDao() {
+    }
+
+    public static synchronized InmemoryLineDao getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new InmemoryLineDao();
+        }
+        return INSTANCE;
+    }
+
+    public void clear() {
+        lines.clear();
+    }
+
+    @Override
+    public Line save(final Line line) {
+        Line persistLine = createNewObject(line);
+        lines.put(persistLine.getId(), persistLine);
+        return persistLine;
+    }
+
+    private Line createNewObject(Line line) {
+        Field field = ReflectionUtils.findField(Line.class, "id");
+        field.setAccessible(true);
+        ReflectionUtils.setField(field, line, ++seq);
+        return line;
+    }
+
+    @Override
+    public Line findById(final Long id) {
+        return lines.get(id);
+    }
+
+    @Override
+    public List<Line> findAll() {
+        return new ArrayList<>(lines.values());
+    }
+
+    @Override
+    public boolean existByName(final String name) {
+        return lines.values()
+                .stream()
+                .anyMatch(line -> line.isSameName(name));
+    }
+
+    @Override
+    public int update(final Line line) {
+        lines.put(line.getId(), line);
+        return 1;
+    }
+
+    @Override
+    public int delete(final Long id) {
+        lines.remove(id);
+        return 1;
+    }
+}

--- a/src/main/java/wooteco/subway/dao/InmemoryLineDao.java
+++ b/src/main/java/wooteco/subway/dao/InmemoryLineDao.java
@@ -11,9 +11,8 @@ import wooteco.subway.domain.Line;
 public class InmemoryLineDao implements LineDao {
 
     private static InmemoryLineDao INSTANCE;
-
-    private Long seq = 0L;
     private final Map<Long, Line> lines = new HashMap<>();
+    private Long seq = 0L;
 
     private InmemoryLineDao() {
     }

--- a/src/main/java/wooteco/subway/dao/InmemoryLineDao.java
+++ b/src/main/java/wooteco/subway/dao/InmemoryLineDao.java
@@ -60,6 +60,11 @@ public class InmemoryLineDao implements LineDao {
     }
 
     @Override
+    public boolean existById(final Long id) {
+        return lines.containsKey(id);
+    }
+
+    @Override
     public int update(final Line line) {
         lines.put(line.getId(), line);
         return 1;

--- a/src/main/java/wooteco/subway/dao/InmemoryStationDao.java
+++ b/src/main/java/wooteco/subway/dao/InmemoryStationDao.java
@@ -11,9 +11,8 @@ import wooteco.subway.domain.Station;
 public class InmemoryStationDao implements StationDao {
 
     private static InmemoryStationDao INSTANCE;
-
-    private Long seq = 0L;
     private final Map<Long, Station> stations = new HashMap<>();
+    private Long seq = 0L;
 
     private InmemoryStationDao() {
     }

--- a/src/main/java/wooteco/subway/dao/InmemoryStationDao.java
+++ b/src/main/java/wooteco/subway/dao/InmemoryStationDao.java
@@ -1,0 +1,63 @@
+package wooteco.subway.dao;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.util.ReflectionUtils;
+import wooteco.subway.domain.Station;
+
+public class InmemoryStationDao implements StationDao {
+
+    private static InmemoryStationDao INSTANCE;
+
+    private Long seq = 0L;
+    private final Map<Long, Station> stations = new HashMap<>();
+
+    private InmemoryStationDao() {
+    }
+
+    public static synchronized InmemoryStationDao getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new InmemoryStationDao();
+        }
+        return INSTANCE;
+    }
+
+    public void clear() {
+        stations.clear();
+    }
+
+    @Override
+    public Station save(Station station) {
+        Station persistStation = createNewObject(station);
+        stations.put(persistStation.getId(), persistStation);
+        return persistStation;
+    }
+
+    private Station createNewObject(Station station) {
+        Field field = ReflectionUtils.findField(Station.class, "id");
+        field.setAccessible(true);
+        ReflectionUtils.setField(field, station, ++seq);
+        return station;
+    }
+
+    @Override
+    public List<Station> findAll() {
+        return new ArrayList<>(stations.values());
+    }
+
+    @Override
+    public boolean existByName(final String name) {
+        return stations.values()
+                .stream()
+                .anyMatch(station -> station.isSameName(name));
+    }
+
+    @Override
+    public int delete(final Long stationId) {
+        stations.remove(stationId);
+        return 1;
+    }
+}

--- a/src/main/java/wooteco/subway/dao/InmemoryStationDao.java
+++ b/src/main/java/wooteco/subway/dao/InmemoryStationDao.java
@@ -55,6 +55,11 @@ public class InmemoryStationDao implements StationDao {
     }
 
     @Override
+    public boolean existById(final Long id) {
+        return stations.containsKey(id);
+    }
+
+    @Override
     public int delete(final Long stationId) {
         stations.remove(stationId);
         return 1;

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -36,6 +36,7 @@ public class JdbcLineDao implements LineDao {
             ps.setString(2, line.getColor());
             return ps;
         }, keyHolder);
+
         long id = Objects.requireNonNull(keyHolder.getKey()).longValue();
         return new Line(id, line.getName(), line.getColor());
     }

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -55,7 +55,7 @@ public class JdbcLineDao implements LineDao {
 
     @Override
     public boolean existByName(final String name) {
-        final String sql = "select exists(select * from LINE where name = ?)";
+        final String sql = "select exists (select * from LINE where name = ?)";
         return jdbcTemplate.queryForObject(sql, Boolean.class, name);
     }
 

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -59,6 +59,11 @@ public class JdbcLineDao implements LineDao {
     }
 
     @Override
+    public boolean existById(final Long id) {
+        return false;
+    }
+
+    @Override
     public int update(final Line line) {
         final String sql = "update LINE set name = ?, color = ? where id = ?";
         return jdbcTemplate.update(sql, line.getName(), line.getColor(), line.getId());

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -60,7 +60,8 @@ public class JdbcLineDao implements LineDao {
 
     @Override
     public int update(final Line line) {
-        return 0;
+        final String sql = "update LINE set name = ?, color = ? where id = ?";
+        return jdbcTemplate.update(sql, line.getName(), line.getColor(), line.getId());
     }
 
     @Override

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -1,0 +1,61 @@
+package wooteco.subway.dao;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+import wooteco.subway.domain.Line;
+
+@Repository
+public class JdbcLineDao implements LineDao {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public JdbcLineDao(final JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public Line save(final Line line) {
+        final String sql = "insert into LINE (name, color) values(?, ?)";
+
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement(sql, new String[] { "id" });
+            ps.setString(1, line.getName());
+            ps.setString(2, line.getColor());
+            return ps;
+        }, keyHolder);
+        long id = Objects.requireNonNull(keyHolder.getKey()).longValue();
+        return new Line(id, line.getName(), line.getColor());
+    }
+
+    @Override
+    public Line findById(final Long id) {
+        return null;
+    }
+
+    @Override
+    public List<Line> findAll() {
+        return null;
+    }
+
+    @Override
+    public boolean existByName(final String name) {
+        return false;
+    }
+
+    @Override
+    public int update(final Line line) {
+        return 0;
+    }
+
+    @Override
+    public int delete(final Long id) {
+        return 0;
+    }
+}

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -60,7 +60,8 @@ public class JdbcLineDao implements LineDao {
 
     @Override
     public boolean existById(final Long id) {
-        return false;
+        final String sql = "select exists (select * from LINE where id = ?)";
+        return jdbcTemplate.queryForObject(sql, Boolean.class, id);
     }
 
     @Override

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -3,8 +3,8 @@ package wooteco.subway.dao;
 import java.sql.PreparedStatement;
 import java.util.List;
 import java.util.Objects;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
@@ -19,13 +19,19 @@ public class JdbcLineDao implements LineDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
+    private static RowMapper<Line> lineRowMapper = (rs, rowNum) -> new Line(
+            rs.getLong("id"),
+            rs.getString("name"),
+            rs.getString("color")
+    );
+
     @Override
     public Line save(final Line line) {
         final String sql = "insert into LINE (name, color) values(?, ?)";
 
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
-            PreparedStatement ps = connection.prepareStatement(sql, new String[] { "id" });
+            PreparedStatement ps = connection.prepareStatement(sql, new String[]{"id"});
             ps.setString(1, line.getName());
             ps.setString(2, line.getColor());
             return ps;
@@ -37,16 +43,13 @@ public class JdbcLineDao implements LineDao {
     @Override
     public Line findById(final Long id) {
         final String sql = "select * from LINE where id = ?";
-        return jdbcTemplate.queryForObject(sql, (rs, rowNum) -> new Line(
-                rs.getLong("id"),
-                rs.getString("name"),
-                rs.getString("color")
-        ), id);
+        return jdbcTemplate.queryForObject(sql, lineRowMapper, id);
     }
 
     @Override
     public List<Line> findAll() {
-        return null;
+        final String sql = "select * from LINE";
+        return jdbcTemplate.query(sql, lineRowMapper);
     }
 
     @Override

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -36,7 +36,12 @@ public class JdbcLineDao implements LineDao {
 
     @Override
     public Line findById(final Long id) {
-        return null;
+        final String sql = "select * from LINE where id = ?";
+        return jdbcTemplate.queryForObject(sql, (rs, rowNum) -> new Line(
+                rs.getLong("id"),
+                rs.getString("name"),
+                rs.getString("color")
+        ), id);
     }
 
     @Override

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -54,7 +54,8 @@ public class JdbcLineDao implements LineDao {
 
     @Override
     public boolean existByName(final String name) {
-        return false;
+        final String sql = "select exists(select * from LINE where name = ?)";
+        return jdbcTemplate.queryForObject(sql, Boolean.class, name);
     }
 
     @Override

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -14,16 +14,15 @@ import wooteco.subway.domain.Line;
 public class JdbcLineDao implements LineDao {
 
     private final JdbcTemplate jdbcTemplate;
-
-    public JdbcLineDao(final JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
-    }
-
     private final RowMapper<Line> lineRowMapper = (rs, rowNum) -> new Line(
             rs.getLong("id"),
             rs.getString("name"),
             rs.getString("color")
     );
+
+    public JdbcLineDao(final JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
 
     @Override
     public Line save(final Line line) {

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -19,7 +19,7 @@ public class JdbcLineDao implements LineDao {
         this.jdbcTemplate = jdbcTemplate;
     }
 
-    private static RowMapper<Line> lineRowMapper = (rs, rowNum) -> new Line(
+    private final RowMapper<Line> lineRowMapper = (rs, rowNum) -> new Line(
             rs.getLong("id"),
             rs.getString("name"),
             rs.getString("color")

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -66,6 +66,7 @@ public class JdbcLineDao implements LineDao {
 
     @Override
     public int delete(final Long id) {
-        return 0;
+        final String sql = "delete from LINE where id = ?";
+        return jdbcTemplate.update(sql, id);
     }
 }

--- a/src/main/java/wooteco/subway/dao/JdbcStationDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcStationDao.java
@@ -14,15 +14,14 @@ import wooteco.subway.domain.Station;
 public class JdbcStationDao implements StationDao {
 
     private final JdbcTemplate jdbcTemplate;
-
-    public JdbcStationDao(final JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
-    }
-
     private final RowMapper<Station> stationRowMapper = (rs, rowNum) -> new Station(
             rs.getLong("id"),
             rs.getString("name")
     );
+
+    public JdbcStationDao(final JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
 
     @Override
     public Station save(final Station station) {

--- a/src/main/java/wooteco/subway/dao/JdbcStationDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcStationDao.java
@@ -1,0 +1,49 @@
+package wooteco.subway.dao;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+import wooteco.subway.domain.Station;
+
+@Repository
+public class JdbcStationDao implements StationDao {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public JdbcStationDao(final JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public Station save(final Station station) {
+        final String sql = "insert into STATION (name) values (?)";
+
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement(sql, new String[]{"id"});
+            ps.setString(1, station.getName());
+            return ps;
+        }, keyHolder);
+        long id = Objects.requireNonNull(keyHolder.getKey()).longValue();
+        return new Station(id, station.getName());
+    }
+
+    @Override
+    public List<Station> findAll() {
+        return null;
+    }
+
+    @Override
+    public boolean existByName(final String name) {
+        return false;
+    }
+
+    @Override
+    public int delete(final Long stationId) {
+        return 0;
+    }
+}

--- a/src/main/java/wooteco/subway/dao/JdbcStationDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcStationDao.java
@@ -20,8 +20,8 @@ public class JdbcStationDao implements StationDao {
     }
 
     private final RowMapper<Station> stationRowMapper = (rs, rowNum) -> new Station(
-                    rs.getLong("id"),
-                    rs.getString("name")
+            rs.getLong("id"),
+            rs.getString("name")
     );
 
     @Override
@@ -47,7 +47,8 @@ public class JdbcStationDao implements StationDao {
 
     @Override
     public boolean existByName(final String name) {
-        return false;
+        final String sql = "select exists (select * from STATION where name = ?)";
+        return jdbcTemplate.queryForObject(sql, Boolean.class, name);
     }
 
     @Override

--- a/src/main/java/wooteco/subway/dao/JdbcStationDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcStationDao.java
@@ -34,6 +34,7 @@ public class JdbcStationDao implements StationDao {
             ps.setString(1, station.getName());
             return ps;
         }, keyHolder);
+
         long id = Objects.requireNonNull(keyHolder.getKey()).longValue();
         return new Station(id, station.getName());
     }
@@ -51,6 +52,7 @@ public class JdbcStationDao implements StationDao {
 
     @Override
     public int delete(final Long stationId) {
-        return 0;
+        final String sql = "delete from STATION where id = ?";
+        return jdbcTemplate.update(sql, stationId);
     }
 }

--- a/src/main/java/wooteco/subway/dao/JdbcStationDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcStationDao.java
@@ -52,7 +52,8 @@ public class JdbcStationDao implements StationDao {
 
     @Override
     public boolean existById(final Long id) {
-        return false;
+        final String sql = "select exists (select * from STATION where id = ?)";
+        return jdbcTemplate.queryForObject(sql, Boolean.class, id);
     }
 
     @Override

--- a/src/main/java/wooteco/subway/dao/JdbcStationDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcStationDao.java
@@ -51,6 +51,11 @@ public class JdbcStationDao implements StationDao {
     }
 
     @Override
+    public boolean existById(final Long id) {
+        return false;
+    }
+
+    @Override
     public int delete(final Long stationId) {
         final String sql = "delete from STATION where id = ?";
         return jdbcTemplate.update(sql, stationId);

--- a/src/main/java/wooteco/subway/dao/JdbcStationDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcStationDao.java
@@ -4,6 +4,7 @@ import java.sql.PreparedStatement;
 import java.util.List;
 import java.util.Objects;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
@@ -17,6 +18,11 @@ public class JdbcStationDao implements StationDao {
     public JdbcStationDao(final JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
+
+    private final RowMapper<Station> stationRowMapper = (rs, rowNum) -> new Station(
+                    rs.getLong("id"),
+                    rs.getString("name")
+    );
 
     @Override
     public Station save(final Station station) {
@@ -34,7 +40,8 @@ public class JdbcStationDao implements StationDao {
 
     @Override
     public List<Station> findAll() {
-        return null;
+        final String sql = "select * from STATION";
+        return jdbcTemplate.query(sql, stationRowMapper);
     }
 
     @Override

--- a/src/main/java/wooteco/subway/dao/LineDao.java
+++ b/src/main/java/wooteco/subway/dao/LineDao.java
@@ -1,0 +1,29 @@
+package wooteco.subway.dao;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.util.ReflectionUtils;
+import wooteco.subway.domain.Line;
+
+public class LineDao {
+    private Long seq = 0L;
+    private final Map<Long, Line> lines;
+
+    public LineDao() {
+        lines = new HashMap<>();
+    }
+
+    public Line save(final Line line) {
+        Line persistLine = createNewObject(line);
+        lines.put(persistLine.getId(), persistLine);
+        return persistLine;
+    }
+
+    private Line createNewObject(Line line) {
+        Field field = ReflectionUtils.findField(Line.class, "id");
+        field.setAccessible(true);
+        ReflectionUtils.setField(field, line, ++seq);
+        return line;
+    }
+}

--- a/src/main/java/wooteco/subway/dao/LineDao.java
+++ b/src/main/java/wooteco/subway/dao/LineDao.java
@@ -1,68 +1,19 @@
 package wooteco.subway.dao;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import org.springframework.util.ReflectionUtils;
 import wooteco.subway.domain.Line;
 
-public class LineDao {
+public interface LineDao {
 
-    private static LineDao INSTANCE;
+    Line save(Line line);
 
-    private Long seq = 0L;
-    private final Map<Long, Line> lines = new HashMap<>();
+    Line findById(Long id);
 
-    private LineDao() {
-    }
+    List<Line> findAll();
 
-    public static synchronized LineDao getInstance() {
-        if (INSTANCE == null) {
-            INSTANCE = new LineDao();
-        }
-        return INSTANCE;
-    }
+    boolean existByName(String name);
 
-    public void clear() {
-        lines.clear();
-    }
+    int update(Line line);
 
-    public Line save(final Line line) {
-        Line persistLine = createNewObject(line);
-        lines.put(persistLine.getId(), persistLine);
-        return persistLine;
-    }
-
-    private Line createNewObject(Line line) {
-        Field field = ReflectionUtils.findField(Line.class, "id");
-        field.setAccessible(true);
-        ReflectionUtils.setField(field, line, ++seq);
-        return line;
-    }
-
-    public Line findById(final Long id) {
-        return lines.get(id);
-    }
-
-    public List<Line> findAll() {
-        return new ArrayList<>(lines.values());
-    }
-
-    public int update(final Line line) {
-        lines.put(line.getId(), line);
-        return 1;
-    }
-
-    public int delete(final Long id) {
-        lines.remove(id);
-        return 1;
-    }
-
-    public boolean existByName(final String name) {
-        return lines.values()
-                .stream()
-                .anyMatch(line -> line.isSameName(name));
-    }
+    int delete(Long id);
 }

--- a/src/main/java/wooteco/subway/dao/LineDao.java
+++ b/src/main/java/wooteco/subway/dao/LineDao.java
@@ -1,7 +1,9 @@
 package wooteco.subway.dao;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.springframework.util.ReflectionUtils;
 import wooteco.subway.domain.Line;
@@ -29,5 +31,9 @@ public class LineDao {
 
     public Line findById(final Long id) {
         return lines.get(id);
+    }
+
+    public List<Line> findAll() {
+        return new ArrayList<>(lines.values());
     }
 }

--- a/src/main/java/wooteco/subway/dao/LineDao.java
+++ b/src/main/java/wooteco/subway/dao/LineDao.java
@@ -41,4 +41,9 @@ public class LineDao {
         lines.put(line.getId(), line);
         return 1;
     }
+
+    public int delete(final Long id) {
+        lines.remove(id);
+        return 1;
+    }
 }

--- a/src/main/java/wooteco/subway/dao/LineDao.java
+++ b/src/main/java/wooteco/subway/dao/LineDao.java
@@ -36,4 +36,9 @@ public class LineDao {
     public List<Line> findAll() {
         return new ArrayList<>(lines.values());
     }
+
+    public int update(final Line line) {
+        lines.put(line.getId(), line);
+        return 1;
+    }
 }

--- a/src/main/java/wooteco/subway/dao/LineDao.java
+++ b/src/main/java/wooteco/subway/dao/LineDao.java
@@ -26,4 +26,8 @@ public class LineDao {
         ReflectionUtils.setField(field, line, ++seq);
         return line;
     }
+
+    public Line findById(final Long id) {
+        return lines.get(id);
+    }
 }

--- a/src/main/java/wooteco/subway/dao/LineDao.java
+++ b/src/main/java/wooteco/subway/dao/LineDao.java
@@ -9,10 +9,11 @@ import org.springframework.util.ReflectionUtils;
 import wooteco.subway.domain.Line;
 
 public class LineDao {
-    private static final Map<Long, Line> lines = new HashMap<>();
+
     private static LineDao INSTANCE;
 
     private Long seq = 0L;
+    private final Map<Long, Line> lines = new HashMap<>();
 
     private LineDao() {
     }

--- a/src/main/java/wooteco/subway/dao/LineDao.java
+++ b/src/main/java/wooteco/subway/dao/LineDao.java
@@ -13,6 +13,8 @@ public interface LineDao {
 
     boolean existByName(String name);
 
+    boolean existById(Long id);
+
     int update(Line line);
 
     int delete(Long id);

--- a/src/main/java/wooteco/subway/dao/LineDao.java
+++ b/src/main/java/wooteco/subway/dao/LineDao.java
@@ -50,6 +50,6 @@ public class LineDao {
     public boolean existByName(final String name) {
         return lines.values()
                 .stream()
-                .anyMatch(line -> line.getName().equals(name));
+                .anyMatch(line -> line.isSameName(name));
     }
 }

--- a/src/main/java/wooteco/subway/dao/LineDao.java
+++ b/src/main/java/wooteco/subway/dao/LineDao.java
@@ -46,4 +46,10 @@ public class LineDao {
         lines.remove(id);
         return 1;
     }
+
+    public boolean existByName(final String name) {
+        return lines.values()
+                .stream()
+                .anyMatch(line -> line.getName().equals(name));
+    }
 }

--- a/src/main/java/wooteco/subway/dao/LineDao.java
+++ b/src/main/java/wooteco/subway/dao/LineDao.java
@@ -9,11 +9,23 @@ import org.springframework.util.ReflectionUtils;
 import wooteco.subway.domain.Line;
 
 public class LineDao {
-    private Long seq = 0L;
-    private final Map<Long, Line> lines;
+    private static final Map<Long, Line> lines = new HashMap<>();
+    private static LineDao INSTANCE;
 
-    public LineDao() {
-        lines = new HashMap<>();
+    private Long seq = 0L;
+
+    private LineDao() {
+    }
+
+    public static synchronized LineDao getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new LineDao();
+        }
+        return INSTANCE;
+    }
+
+    public void clear() {
+        lines.clear();
     }
 
     public Line save(final Line line) {

--- a/src/main/java/wooteco/subway/dao/StationDao.java
+++ b/src/main/java/wooteco/subway/dao/StationDao.java
@@ -1,30 +1,40 @@
 package wooteco.subway.dao;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.springframework.util.ReflectionUtils;
 import wooteco.subway.domain.Station;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
-
 public class StationDao {
-    private static Long seq = 0L;
-    private static List<Station> stations = new ArrayList<>();
+    private Long seq = 0L;
+    private final Map<Long, Station> stations;
 
-    public static Station save(Station station) {
+    public StationDao() {
+        stations = new HashMap<>();
+    }
+
+    public Station save(Station station) {
         Station persistStation = createNewObject(station);
-        stations.add(persistStation);
+        stations.put(persistStation.getId(), persistStation);
         return persistStation;
     }
 
-    private static Station createNewObject(Station station) {
+    private Station createNewObject(Station station) {
         Field field = ReflectionUtils.findField(Station.class, "id");
         field.setAccessible(true);
         ReflectionUtils.setField(field, station, ++seq);
         return station;
     }
 
-    public static List<Station> findAll() {
-        return stations;
+    public List<Station> findAll() {
+        return new ArrayList<>(stations.values());
+    }
+
+    public int delete(final Long stationId) {
+        stations.remove(stationId);
+        return 1;
     }
 }

--- a/src/main/java/wooteco/subway/dao/StationDao.java
+++ b/src/main/java/wooteco/subway/dao/StationDao.java
@@ -41,6 +41,6 @@ public class StationDao {
     public boolean existByName(final String name) {
         return stations.values()
                 .stream()
-                .anyMatch(station -> station.getName().equals(name));
+                .anyMatch(station -> station.isSameName(name));
     }
 }

--- a/src/main/java/wooteco/subway/dao/StationDao.java
+++ b/src/main/java/wooteco/subway/dao/StationDao.java
@@ -37,4 +37,10 @@ public class StationDao {
         stations.remove(stationId);
         return 1;
     }
+
+    public boolean existByName(final String name) {
+        return stations.values()
+                .stream()
+                .anyMatch(station -> station.getName().equals(name));
+    }
 }

--- a/src/main/java/wooteco/subway/dao/StationDao.java
+++ b/src/main/java/wooteco/subway/dao/StationDao.java
@@ -11,5 +11,7 @@ public interface StationDao {
 
     boolean existByName(String name);
 
+    boolean existById(Long id);
+
     int delete(Long stationId);
 }

--- a/src/main/java/wooteco/subway/dao/StationDao.java
+++ b/src/main/java/wooteco/subway/dao/StationDao.java
@@ -1,59 +1,15 @@
 package wooteco.subway.dao;
 
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import org.springframework.util.ReflectionUtils;
 import wooteco.subway.domain.Station;
 
-public class StationDao {
+public interface StationDao {
 
-    private static StationDao INSTANCE;
+    Station save(Station station);
 
-    private Long seq = 0L;
-    private final Map<Long, Station> stations = new HashMap<>();
+    List<Station> findAll();
 
-    private StationDao() {
-    }
+    boolean existByName(String name);
 
-    public static synchronized StationDao getInstance() {
-        if (INSTANCE == null) {
-            INSTANCE = new StationDao();
-        }
-        return INSTANCE;
-    }
-
-    public void clear() {
-        stations.clear();
-    }
-
-    public Station save(Station station) {
-        Station persistStation = createNewObject(station);
-        stations.put(persistStation.getId(), persistStation);
-        return persistStation;
-    }
-
-    private Station createNewObject(Station station) {
-        Field field = ReflectionUtils.findField(Station.class, "id");
-        field.setAccessible(true);
-        ReflectionUtils.setField(field, station, ++seq);
-        return station;
-    }
-
-    public List<Station> findAll() {
-        return new ArrayList<>(stations.values());
-    }
-
-    public int delete(final Long stationId) {
-        stations.remove(stationId);
-        return 1;
-    }
-
-    public boolean existByName(final String name) {
-        return stations.values()
-                .stream()
-                .anyMatch(station -> station.isSameName(name));
-    }
+    int delete(Long stationId);
 }

--- a/src/main/java/wooteco/subway/dao/StationDao.java
+++ b/src/main/java/wooteco/subway/dao/StationDao.java
@@ -9,11 +9,24 @@ import org.springframework.util.ReflectionUtils;
 import wooteco.subway.domain.Station;
 
 public class StationDao {
-    private Long seq = 0L;
-    private final Map<Long, Station> stations;
 
-    public StationDao() {
-        stations = new HashMap<>();
+    private static StationDao INSTANCE;
+
+    private Long seq = 0L;
+    private final Map<Long, Station> stations = new HashMap<>();
+
+    private StationDao() {
+    }
+
+    public static synchronized StationDao getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new StationDao();
+        }
+        return INSTANCE;
+    }
+
+    public void clear() {
+        stations.clear();
     }
 
     public Station save(Station station) {

--- a/src/main/java/wooteco/subway/dao/StationDao.java
+++ b/src/main/java/wooteco/subway/dao/StationDao.java
@@ -17,14 +17,14 @@ public class StationDao {
         return persistStation;
     }
 
-    public static List<Station> findAll() {
-        return stations;
-    }
-
     private static Station createNewObject(Station station) {
         Field field = ReflectionUtils.findField(Station.class, "id");
         field.setAccessible(true);
         ReflectionUtils.setField(field, station, ++seq);
         return station;
+    }
+
+    public static List<Station> findAll() {
+        return stations;
     }
 }

--- a/src/main/java/wooteco/subway/domain/Line.java
+++ b/src/main/java/wooteco/subway/domain/Line.java
@@ -1,5 +1,7 @@
 package wooteco.subway.domain;
 
+import java.util.Objects;
+
 public class Line {
 
     private final Long id;
@@ -26,5 +28,22 @@ public class Line {
 
     public String getColor() {
         return color;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Line line = (Line) o;
+        return Objects.equals(id, line.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/wooteco/subway/domain/Line.java
+++ b/src/main/java/wooteco/subway/domain/Line.java
@@ -12,6 +12,10 @@ public class Line {
         this.color = color;
     }
 
+    public Line(final String name, final String color) {
+        this(null, name, color);
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/wooteco/subway/domain/Line.java
+++ b/src/main/java/wooteco/subway/domain/Line.java
@@ -1,0 +1,26 @@
+package wooteco.subway.domain;
+
+public class Line {
+
+    private final Long id;
+    private final String name;
+    private final String color;
+
+    public Line(final Long id, final String name, final String color) {
+        this.id = id;
+        this.name = name;
+        this.color = color;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+}

--- a/src/main/java/wooteco/subway/domain/Line.java
+++ b/src/main/java/wooteco/subway/domain/Line.java
@@ -18,6 +18,10 @@ public class Line {
         this(null, name, color);
     }
 
+    public boolean isSameName(final String name) {
+        return this.name.equals(name);
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/wooteco/subway/domain/Station.java
+++ b/src/main/java/wooteco/subway/domain/Station.java
@@ -1,5 +1,7 @@
 package wooteco.subway.domain;
 
+import java.util.Objects;
+
 public class Station {
 
     private Long id;
@@ -23,6 +25,23 @@ public class Station {
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Station station = (Station) o;
+        return Objects.equals(id, station.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }
 

--- a/src/main/java/wooteco/subway/domain/Station.java
+++ b/src/main/java/wooteco/subway/domain/Station.java
@@ -1,6 +1,7 @@
 package wooteco.subway.domain;
 
 public class Station {
+
     private Long id;
     private String name;
 

--- a/src/main/java/wooteco/subway/domain/Station.java
+++ b/src/main/java/wooteco/subway/domain/Station.java
@@ -19,6 +19,10 @@ public class Station {
         this.name = name;
     }
 
+    public boolean isSameName(final String name) {
+        return this.name.equals(name);
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/wooteco/subway/dto/LineRequest.java
+++ b/src/main/java/wooteco/subway/dto/LineRequest.java
@@ -1,10 +1,14 @@
 package wooteco.subway.dto;
 
+import javax.validation.constraints.NotBlank;
 import wooteco.subway.domain.Line;
 
 public class LineRequest {
 
+    @NotBlank(message = "line 이름은 공백 혹은 null이 들어올 수 없습니다.")
     private String name;
+
+    @NotBlank(message = "line 색상은 공백 혹은 null이 들어올 수 없습니다.")
     private String color;
 
     private LineRequest() {

--- a/src/main/java/wooteco/subway/dto/LineRequest.java
+++ b/src/main/java/wooteco/subway/dto/LineRequest.java
@@ -14,11 +14,6 @@ public class LineRequest {
     private LineRequest() {
     }
 
-    private LineRequest(String name, String color) {
-        this.name = name;
-        this.color = color;
-    }
-
     public Line toLine() {
         return new Line(name, color);
     }

--- a/src/main/java/wooteco/subway/dto/LineRequest.java
+++ b/src/main/java/wooteco/subway/dto/LineRequest.java
@@ -19,6 +19,10 @@ public class LineRequest {
         return new Line(name, color);
     }
 
+    public Line toLineWithId(final Long id) {
+        return new Line(id, name, color);
+    }
+
     public String getName() {
         return name;
     }

--- a/src/main/java/wooteco/subway/dto/LineRequest.java
+++ b/src/main/java/wooteco/subway/dto/LineRequest.java
@@ -1,21 +1,22 @@
 package wooteco.subway.dto;
 
+import wooteco.subway.domain.Line;
+
 public class LineRequest {
+
     private String name;
     private String color;
-    private Long upStationId;
-    private Long downStationId;
-    private int distance;
 
-    public LineRequest() {
+    private LineRequest() {
     }
 
-    public LineRequest(String name, String color, Long upStationId, Long downStationId, int distance) {
+    private LineRequest(String name, String color) {
         this.name = name;
         this.color = color;
-        this.upStationId = upStationId;
-        this.downStationId = downStationId;
-        this.distance = distance;
+    }
+
+    public Line toLine() {
+        return new Line(name, color);
     }
 
     public String getName() {
@@ -24,17 +25,5 @@ public class LineRequest {
 
     public String getColor() {
         return color;
-    }
-
-    public Long getUpStationId() {
-        return upStationId;
-    }
-
-    public Long getDownStationId() {
-        return downStationId;
-    }
-
-    public int getDistance() {
-        return distance;
     }
 }

--- a/src/main/java/wooteco/subway/dto/LineResponse.java
+++ b/src/main/java/wooteco/subway/dto/LineResponse.java
@@ -1,20 +1,27 @@
 package wooteco.subway.dto;
 
+import wooteco.subway.domain.Line;
 import wooteco.subway.dto.StationResponse;
 
 import java.util.List;
 
 public class LineResponse {
+
     private Long id;
     private String name;
     private String color;
-    private List<StationResponse> stations;
 
-    public LineResponse(Long id, String name, String color, List<StationResponse> stations) {
+    private LineResponse() {
+    }
+
+    private LineResponse(Long id, String name, String color) {
         this.id = id;
         this.name = name;
         this.color = color;
-        this.stations = stations;
+    }
+
+    public static LineResponse from(Line line) {
+        return new LineResponse(line.getId(), line.getName(), line.getColor());
     }
 
     public Long getId() {
@@ -27,9 +34,5 @@ public class LineResponse {
 
     public String getColor() {
         return color;
-    }
-
-    public List<StationResponse> getStations() {
-        return stations;
     }
 }

--- a/src/main/java/wooteco/subway/dto/LineResponse.java
+++ b/src/main/java/wooteco/subway/dto/LineResponse.java
@@ -1,9 +1,6 @@
 package wooteco.subway.dto;
 
 import wooteco.subway.domain.Line;
-import wooteco.subway.dto.StationResponse;
-
-import java.util.List;
 
 public class LineResponse {
 

--- a/src/main/java/wooteco/subway/dto/StationRequest.java
+++ b/src/main/java/wooteco/subway/dto/StationRequest.java
@@ -1,9 +1,11 @@
 package wooteco.subway.dto;
 
+import javax.validation.constraints.NotBlank;
 import wooteco.subway.domain.Station;
 
 public class StationRequest {
 
+    @NotBlank(message = "station 이름은 공백 혹은 null이 들어올 수 없습니다.")
     private String name;
 
     private StationRequest() {

--- a/src/main/java/wooteco/subway/dto/StationRequest.java
+++ b/src/main/java/wooteco/subway/dto/StationRequest.java
@@ -1,13 +1,16 @@
 package wooteco.subway.dto;
 
+import wooteco.subway.domain.Station;
+
 public class StationRequest {
+
     private String name;
 
-    public StationRequest() {
+    private StationRequest() {
     }
 
-    public StationRequest(String name) {
-        this.name = name;
+    public Station toStation() {
+        return new Station(name);
     }
 
     public String getName() {

--- a/src/main/java/wooteco/subway/dto/StationResponse.java
+++ b/src/main/java/wooteco/subway/dto/StationResponse.java
@@ -1,15 +1,22 @@
 package wooteco.subway.dto;
 
+import wooteco.subway.domain.Station;
+
 public class StationResponse {
+
     private Long id;
     private String name;
 
-    public StationResponse() {
+    private StationResponse() {
     }
 
-    public StationResponse(Long id, String name) {
+    private StationResponse(Long id, String name) {
         this.id = id;
         this.name = name;
+    }
+
+    public static StationResponse from(Station station) {
+        return new StationResponse(station.getId(), station.getName());
     }
 
     public Long getId() {

--- a/src/main/java/wooteco/subway/dto/SubwayErrorResponse.java
+++ b/src/main/java/wooteco/subway/dto/SubwayErrorResponse.java
@@ -1,6 +1,12 @@
 package wooteco.subway.dto;
 
+import java.util.stream.Collectors;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
 public class SubwayErrorResponse {
+
+    private static final String MESSAGE_JOINING_DELIMITER = ",";
 
     private String message;
 
@@ -13,6 +19,14 @@ public class SubwayErrorResponse {
 
     public static SubwayErrorResponse from(RuntimeException exception) {
         return new SubwayErrorResponse(exception.getMessage());
+    }
+
+    public static SubwayErrorResponse from(MethodArgumentNotValidException exception) {
+        return new SubwayErrorResponse(exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.joining(MESSAGE_JOINING_DELIMITER)));
     }
 
     public String getMessage() {

--- a/src/main/java/wooteco/subway/dto/SubwayErrorResponse.java
+++ b/src/main/java/wooteco/subway/dto/SubwayErrorResponse.java
@@ -1,0 +1,21 @@
+package wooteco.subway.dto;
+
+public class SubwayErrorResponse {
+
+    private String message;
+
+    private SubwayErrorResponse() {
+    }
+
+    private SubwayErrorResponse(final String message) {
+        this.message = message;
+    }
+
+    public static SubwayErrorResponse from(RuntimeException exception) {
+        return new SubwayErrorResponse(exception.getMessage());
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/wooteco/subway/exception/NotFoundException.java
+++ b/src/main/java/wooteco/subway/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package wooteco.subway.exception;
+
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/wooteco/subway/service/LineService.java
+++ b/src/main/java/wooteco/subway/service/LineService.java
@@ -2,6 +2,7 @@ package wooteco.subway.service;
 
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import wooteco.subway.dao.LineDao;
 import wooteco.subway.domain.Line;
 
@@ -14,6 +15,7 @@ public class LineService {
         this.lineDao = lineDao;
     }
 
+    @Transactional
     public Line save(final Line line) {
         if (lineDao.existByName(line.getName())) {
             throw new IllegalStateException("이미 존재하는 노선 이름입니다.");

--- a/src/main/java/wooteco/subway/service/LineService.java
+++ b/src/main/java/wooteco/subway/service/LineService.java
@@ -13,6 +13,9 @@ public class LineService {
     }
 
     public Line save(final Line line) {
+        if (lineDao.existByName(line.getName())) {
+            throw new IllegalStateException("이미 존재하는 노선 이름입니다.");
+        }
         return lineDao.save(line);
     }
 

--- a/src/main/java/wooteco/subway/service/LineService.java
+++ b/src/main/java/wooteco/subway/service/LineService.java
@@ -1,9 +1,11 @@
 package wooteco.subway.service;
 
 import java.util.List;
+import org.springframework.stereotype.Service;
 import wooteco.subway.dao.LineDao;
 import wooteco.subway.domain.Line;
 
+@Service
 public class LineService {
 
     private final LineDao lineDao;

--- a/src/main/java/wooteco/subway/service/LineService.java
+++ b/src/main/java/wooteco/subway/service/LineService.java
@@ -1,0 +1,34 @@
+package wooteco.subway.service;
+
+import java.util.List;
+import wooteco.subway.dao.LineDao;
+import wooteco.subway.domain.Line;
+
+public class LineService {
+
+    private final LineDao lineDao;
+
+    public LineService(final LineDao lineDao) {
+        this.lineDao = lineDao;
+    }
+
+    public Line save(final Line line) {
+        return lineDao.save(line);
+    }
+
+    public List<Line> findAll() {
+        return lineDao.findAll();
+    }
+
+    public Line findById(final Long lineId) {
+        return lineDao.findById(lineId);
+    }
+
+    public void update(final Line line) {
+        lineDao.update(line);
+    }
+
+    public void delete(final Long lineId) {
+        lineDao.delete(lineId);
+    }
+}

--- a/src/main/java/wooteco/subway/service/LineService.java
+++ b/src/main/java/wooteco/subway/service/LineService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wooteco.subway.dao.LineDao;
 import wooteco.subway.domain.Line;
+import wooteco.subway.exception.NotFoundException;
 
 @Service
 public class LineService {
@@ -31,11 +32,19 @@ public class LineService {
         return lineDao.findById(lineId);
     }
 
+    @Transactional
     public void update(final Line line) {
+        checkExistLine(line);
         lineDao.update(line);
     }
 
     public void delete(final Long lineId) {
         lineDao.delete(lineId);
+    }
+
+    private void checkExistLine(final Line line) {
+        if (!lineDao.existById(line.getId())) {
+            throw new NotFoundException("존재하지 않는 Line입니다.");
+        }
     }
 }

--- a/src/main/java/wooteco/subway/service/LineService.java
+++ b/src/main/java/wooteco/subway/service/LineService.java
@@ -34,16 +34,18 @@ public class LineService {
 
     @Transactional
     public void update(final Line line) {
-        checkExistLine(line);
+        checkExistLine(line.getId());
         lineDao.update(line);
     }
 
+    @Transactional
     public void delete(final Long lineId) {
+        checkExistLine(lineId);
         lineDao.delete(lineId);
     }
 
-    private void checkExistLine(final Line line) {
-        if (!lineDao.existById(line.getId())) {
+    private void checkExistLine(final Long lineId) {
+        if (!lineDao.existById(lineId)) {
             throw new NotFoundException("존재하지 않는 Line입니다.");
         }
     }

--- a/src/main/java/wooteco/subway/service/StationService.java
+++ b/src/main/java/wooteco/subway/service/StationService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wooteco.subway.dao.StationDao;
 import wooteco.subway.domain.Station;
+import wooteco.subway.exception.NotFoundException;
 
 @Service
 public class StationService {
@@ -27,7 +28,15 @@ public class StationService {
         return stationDao.findAll();
     }
 
+    @Transactional
     public void delete(final Long stationId) {
+        checkExistStation(stationId);
         stationDao.delete(stationId);
+    }
+
+    private void checkExistStation(final Long stationId) {
+        if (!stationDao.existById(stationId)) {
+            throw new NotFoundException("존재하지 않는 Station입니다.");
+        }
     }
 }

--- a/src/main/java/wooteco/subway/service/StationService.java
+++ b/src/main/java/wooteco/subway/service/StationService.java
@@ -2,6 +2,7 @@ package wooteco.subway.service;
 
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import wooteco.subway.dao.StationDao;
 import wooteco.subway.domain.Station;
 
@@ -14,6 +15,7 @@ public class StationService {
         this.stationDao = stationDao;
     }
 
+    @Transactional
     public Station save(final Station station) {
         if (stationDao.existByName(station.getName())) {
             throw new IllegalStateException("이미 존재하는 역 이름입니다.");

--- a/src/main/java/wooteco/subway/service/StationService.java
+++ b/src/main/java/wooteco/subway/service/StationService.java
@@ -13,6 +13,9 @@ public class StationService {
     }
 
     public Station save(final Station station) {
+        if (stationDao.existByName(station.getName())) {
+            throw new IllegalStateException("이미 존재하는 역 이름입니다.");
+        }
         return stationDao.save(station);
     }
 

--- a/src/main/java/wooteco/subway/service/StationService.java
+++ b/src/main/java/wooteco/subway/service/StationService.java
@@ -1,29 +1,29 @@
 package wooteco.subway.service;
 
 import java.util.List;
-import wooteco.subway.dao.StationDao;
+import wooteco.subway.dao.InmemoryStationDao;
 import wooteco.subway.domain.Station;
 
 public class StationService {
 
-    private final StationDao stationDao;
+    private final InmemoryStationDao inmemoryStationDao;
 
-    public StationService(final StationDao stationDao) {
-        this.stationDao = stationDao;
+    public StationService(final InmemoryStationDao inmemoryStationDao) {
+        this.inmemoryStationDao = inmemoryStationDao;
     }
 
     public Station save(final Station station) {
-        if (stationDao.existByName(station.getName())) {
+        if (inmemoryStationDao.existByName(station.getName())) {
             throw new IllegalStateException("이미 존재하는 역 이름입니다.");
         }
-        return stationDao.save(station);
+        return inmemoryStationDao.save(station);
     }
 
     public List<Station> findAll() {
-        return stationDao.findAll();
+        return inmemoryStationDao.findAll();
     }
 
     public void delete(final Long stationId) {
-        stationDao.delete(stationId);
+        inmemoryStationDao.delete(stationId);
     }
 }

--- a/src/main/java/wooteco/subway/service/StationService.java
+++ b/src/main/java/wooteco/subway/service/StationService.java
@@ -1,29 +1,31 @@
 package wooteco.subway.service;
 
 import java.util.List;
-import wooteco.subway.dao.InmemoryStationDao;
+import org.springframework.stereotype.Service;
+import wooteco.subway.dao.StationDao;
 import wooteco.subway.domain.Station;
 
+@Service
 public class StationService {
 
-    private final InmemoryStationDao inmemoryStationDao;
+    private final StationDao stationDao;
 
-    public StationService(final InmemoryStationDao inmemoryStationDao) {
-        this.inmemoryStationDao = inmemoryStationDao;
+    public StationService(final StationDao stationDao) {
+        this.stationDao = stationDao;
     }
 
     public Station save(final Station station) {
-        if (inmemoryStationDao.existByName(station.getName())) {
+        if (stationDao.existByName(station.getName())) {
             throw new IllegalStateException("이미 존재하는 역 이름입니다.");
         }
-        return inmemoryStationDao.save(station);
+        return stationDao.save(station);
     }
 
     public List<Station> findAll() {
-        return inmemoryStationDao.findAll();
+        return stationDao.findAll();
     }
 
     public void delete(final Long stationId) {
-        inmemoryStationDao.delete(stationId);
+        stationDao.delete(stationId);
     }
 }

--- a/src/main/java/wooteco/subway/service/StationService.java
+++ b/src/main/java/wooteco/subway/service/StationService.java
@@ -1,0 +1,26 @@
+package wooteco.subway.service;
+
+import java.util.List;
+import wooteco.subway.dao.StationDao;
+import wooteco.subway.domain.Station;
+
+public class StationService {
+
+    private final StationDao stationDao;
+
+    public StationService(final StationDao stationDao) {
+        this.stationDao = stationDao;
+    }
+
+    public Station save(final Station station) {
+        return stationDao.save(station);
+    }
+
+    public List<Station> findAll() {
+        return stationDao.findAll();
+    }
+
+    public void delete(final Long stationId) {
+        stationDao.delete(stationId);
+    }
+}

--- a/src/main/java/wooteco/subway/ui/LineController.java
+++ b/src/main/java/wooteco/subway/ui/LineController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import wooteco.subway.dao.LineDao;
+import wooteco.subway.dao.InmemoryLineDao;
 import wooteco.subway.domain.Line;
 import wooteco.subway.dto.LineRequest;
 import wooteco.subway.dto.LineResponse;
@@ -22,7 +22,7 @@ import wooteco.subway.service.LineService;
 @RequestMapping("/lines")
 public class LineController {
 
-    private final LineService lineService = new LineService(LineDao.getInstance());
+    private final LineService lineService = new LineService(InmemoryLineDao.getInstance());
 
     @PostMapping
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {

--- a/src/main/java/wooteco/subway/ui/LineController.java
+++ b/src/main/java/wooteco/subway/ui/LineController.java
@@ -1,7 +1,10 @@
 package wooteco.subway.ui;
 
 import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,5 +23,15 @@ public class LineController {
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
         Line line = lineService.save(lineRequest.toLine());
         return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(LineResponse.from(line));
+    }
+
+    @GetMapping("/lines")
+    public ResponseEntity<List<LineResponse>> findAllLines() {
+        List<LineResponse> lineRespones = lineService.findAll()
+                .stream()
+                .map(LineResponse::from)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok().body(lineRespones);
     }
 }

--- a/src/main/java/wooteco/subway/ui/LineController.java
+++ b/src/main/java/wooteco/subway/ui/LineController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import wooteco.subway.dao.InmemoryLineDao;
 import wooteco.subway.domain.Line;
 import wooteco.subway.dto.LineRequest;
 import wooteco.subway.dto.LineResponse;
@@ -22,7 +21,11 @@ import wooteco.subway.service.LineService;
 @RequestMapping("/lines")
 public class LineController {
 
-    private final LineService lineService = new LineService(InmemoryLineDao.getInstance());
+    private final LineService lineService;
+
+    public LineController(final LineService lineService) {
+        this.lineService = lineService;
+    }
 
     @PostMapping
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {

--- a/src/main/java/wooteco/subway/ui/LineController.java
+++ b/src/main/java/wooteco/subway/ui/LineController.java
@@ -29,7 +29,7 @@ public class LineController {
     }
 
     @GetMapping("/lines")
-    public ResponseEntity<List<LineResponse>> findAllLines() {
+    public ResponseEntity<List<LineResponse>> showLines() {
         List<LineResponse> lineRespones = lineService.findAll()
                 .stream()
                 .map(LineResponse::from)
@@ -39,7 +39,7 @@ public class LineController {
     }
 
     @GetMapping("/lines/{lineId}")
-    public ResponseEntity<LineResponse> findLine(@PathVariable Long lineId) {
+    public ResponseEntity<LineResponse> showLine(@PathVariable Long lineId) {
         Line line = lineService.findById(lineId);
         return ResponseEntity.ok().body(LineResponse.from(line));
     }

--- a/src/main/java/wooteco/subway/ui/LineController.java
+++ b/src/main/java/wooteco/subway/ui/LineController.java
@@ -1,0 +1,24 @@
+package wooteco.subway.ui;
+
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import wooteco.subway.dao.LineDao;
+import wooteco.subway.domain.Line;
+import wooteco.subway.dto.LineRequest;
+import wooteco.subway.dto.LineResponse;
+import wooteco.subway.service.LineService;
+
+@RestController
+public class LineController {
+
+    private final LineService lineService = new LineService(new LineDao());
+
+    @PostMapping("/lines")
+    public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
+        Line line = lineService.save(lineRequest.toLine());
+        return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(LineResponse.from(line));
+    }
+}

--- a/src/main/java/wooteco/subway/ui/LineController.java
+++ b/src/main/java/wooteco/subway/ui/LineController.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,5 +48,11 @@ public class LineController {
     public ResponseEntity<Void> updateLine(@PathVariable Long lineId, @RequestBody LineRequest lineRequest) {
         lineService.update(lineRequest.toLineWithId(lineId));
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/lines/{lineId}")
+    public ResponseEntity<Void> deleteLine(@PathVariable Long lineId) {
+        lineService.delete(lineId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/wooteco/subway/ui/LineController.java
+++ b/src/main/java/wooteco/subway/ui/LineController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import wooteco.subway.dao.LineDao;
@@ -40,5 +41,11 @@ public class LineController {
     public ResponseEntity<LineResponse> findLine(@PathVariable Long lineId) {
         Line line = lineService.findById(lineId);
         return ResponseEntity.ok().body(LineResponse.from(line));
+    }
+
+    @PutMapping("/lines/{lineId}")
+    public ResponseEntity<Void> updateLine(@PathVariable Long lineId, @RequestBody LineRequest lineRequest) {
+        lineService.update(lineRequest.toLineWithId(lineId));
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/wooteco/subway/ui/LineController.java
+++ b/src/main/java/wooteco/subway/ui/LineController.java
@@ -3,6 +3,7 @@ package wooteco.subway.ui;
 import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +29,7 @@ public class LineController {
     }
 
     @PostMapping
-    public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
+    public ResponseEntity<LineResponse> createLine(@RequestBody @Valid LineRequest lineRequest) {
         Line line = lineService.save(lineRequest.toLine());
         return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(LineResponse.from(line));
     }
@@ -50,7 +51,7 @@ public class LineController {
     }
 
     @PutMapping("/{lineId}")
-    public ResponseEntity<Void> updateLine(@PathVariable Long lineId, @RequestBody LineRequest lineRequest) {
+    public ResponseEntity<Void> updateLine(@PathVariable Long lineId, @RequestBody @Valid LineRequest lineRequest) {
         lineService.update(lineRequest.toLineWithId(lineId));
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/wooteco/subway/ui/LineController.java
+++ b/src/main/java/wooteco/subway/ui/LineController.java
@@ -22,7 +22,7 @@ import wooteco.subway.service.LineService;
 @RequestMapping("/lines")
 public class LineController {
 
-    private final LineService lineService = new LineService(new LineDao());
+    private final LineService lineService = new LineService(LineDao.getInstance());
 
     @PostMapping
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {

--- a/src/main/java/wooteco/subway/ui/LineController.java
+++ b/src/main/java/wooteco/subway/ui/LineController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,5 +34,11 @@ public class LineController {
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok().body(lineRespones);
+    }
+
+    @GetMapping("/lines/{lineId}")
+    public ResponseEntity<LineResponse> findLine(@PathVariable Long lineId) {
+        Line line = lineService.findById(lineId);
+        return ResponseEntity.ok().body(LineResponse.from(line));
     }
 }

--- a/src/main/java/wooteco/subway/ui/LineController.java
+++ b/src/main/java/wooteco/subway/ui/LineController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import wooteco.subway.dao.LineDao;
 import wooteco.subway.domain.Line;
@@ -18,17 +19,18 @@ import wooteco.subway.dto.LineResponse;
 import wooteco.subway.service.LineService;
 
 @RestController
+@RequestMapping("/lines")
 public class LineController {
 
     private final LineService lineService = new LineService(new LineDao());
 
-    @PostMapping("/lines")
+    @PostMapping
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
         Line line = lineService.save(lineRequest.toLine());
         return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(LineResponse.from(line));
     }
 
-    @GetMapping("/lines")
+    @GetMapping
     public ResponseEntity<List<LineResponse>> showLines() {
         List<LineResponse> lineRespones = lineService.findAll()
                 .stream()
@@ -38,19 +40,19 @@ public class LineController {
         return ResponseEntity.ok().body(lineRespones);
     }
 
-    @GetMapping("/lines/{lineId}")
+    @GetMapping("/{lineId}")
     public ResponseEntity<LineResponse> showLine(@PathVariable Long lineId) {
         Line line = lineService.findById(lineId);
         return ResponseEntity.ok().body(LineResponse.from(line));
     }
 
-    @PutMapping("/lines/{lineId}")
+    @PutMapping("/{lineId}")
     public ResponseEntity<Void> updateLine(@PathVariable Long lineId, @RequestBody LineRequest lineRequest) {
         lineService.update(lineRequest.toLineWithId(lineId));
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/lines/{lineId}")
+    @DeleteMapping("/{lineId}")
     public ResponseEntity<Void> deleteLine(@PathVariable Long lineId) {
         lineService.delete(lineId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/wooteco/subway/ui/StationController.java
+++ b/src/main/java/wooteco/subway/ui/StationController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import wooteco.subway.dao.StationDao;
+import wooteco.subway.dao.InmemoryStationDao;
 import wooteco.subway.domain.Station;
 import wooteco.subway.dto.StationRequest;
 import wooteco.subway.dto.StationResponse;
@@ -21,7 +21,7 @@ import wooteco.subway.service.StationService;
 @RequestMapping("/stations")
 public class StationController {
 
-    private final StationService stationService = new StationService(StationDao.getInstance());
+    private final StationService stationService = new StationService(InmemoryStationDao.getInstance());
 
     @PostMapping
     public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {

--- a/src/main/java/wooteco/subway/ui/StationController.java
+++ b/src/main/java/wooteco/subway/ui/StationController.java
@@ -3,6 +3,7 @@ package wooteco.subway.ui;
 import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,7 +12,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import wooteco.subway.dao.InmemoryStationDao;
 import wooteco.subway.domain.Station;
 import wooteco.subway.dto.StationRequest;
 import wooteco.subway.dto.StationResponse;
@@ -28,7 +28,7 @@ public class StationController {
     }
 
     @PostMapping
-    public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {
+    public ResponseEntity<StationResponse> createStation(@RequestBody @Valid StationRequest stationRequest) {
         Station station = stationService.save(stationRequest.toStation());
         return ResponseEntity.created(URI.create("/stations/" + station.getId())).body(StationResponse.from(station));
     }

--- a/src/main/java/wooteco/subway/ui/StationController.java
+++ b/src/main/java/wooteco/subway/ui/StationController.java
@@ -21,7 +21,11 @@ import wooteco.subway.service.StationService;
 @RequestMapping("/stations")
 public class StationController {
 
-    private final StationService stationService = new StationService(InmemoryStationDao.getInstance());
+    private final StationService stationService;
+
+    public StationController(final StationService stationService) {
+        this.stationService = stationService;
+    }
 
     @PostMapping
     public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {

--- a/src/main/java/wooteco/subway/ui/StationController.java
+++ b/src/main/java/wooteco/subway/ui/StationController.java
@@ -3,13 +3,13 @@ package wooteco.subway.ui;
 import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import wooteco.subway.dao.StationDao;
 import wooteco.subway.domain.Station;
@@ -18,17 +18,18 @@ import wooteco.subway.dto.StationResponse;
 import wooteco.subway.service.StationService;
 
 @RestController
+@RequestMapping("/stations")
 public class StationController {
 
     private final StationService stationService = new StationService(new StationDao());
 
-    @PostMapping("/stations")
+    @PostMapping
     public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {
         Station station = stationService.save(stationRequest.toStation());
         return ResponseEntity.created(URI.create("/stations/" + station.getId())).body(StationResponse.from(station));
     }
 
-    @GetMapping(value = "/stations", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping
     public ResponseEntity<List<StationResponse>> showStations() {
         List<StationResponse> stationResponses = stationService.findAll()
                 .stream()
@@ -38,7 +39,7 @@ public class StationController {
         return ResponseEntity.ok().body(stationResponses);
     }
 
-    @DeleteMapping("/stations/{stationId}")
+    @DeleteMapping("/{stationId}")
     public ResponseEntity<Void> deleteStation(@PathVariable Long stationId) {
         stationService.delete(stationId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/wooteco/subway/ui/StationController.java
+++ b/src/main/java/wooteco/subway/ui/StationController.java
@@ -21,7 +21,7 @@ import wooteco.subway.service.StationService;
 @RequestMapping("/stations")
 public class StationController {
 
-    private final StationService stationService = new StationService(new StationDao());
+    private final StationService stationService = new StationService(StationDao.getInstance());
 
     @PostMapping
     public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {

--- a/src/main/java/wooteco/subway/ui/StationController.java
+++ b/src/main/java/wooteco/subway/ui/StationController.java
@@ -38,9 +38,9 @@ public class StationController {
         return ResponseEntity.ok().body(stationResponses);
     }
 
-    @DeleteMapping("/stations/{id}")
-    public ResponseEntity<Void> deleteStation(@PathVariable Long id) {
-        stationService.delete(id);
+    @DeleteMapping("/stations/{stationId}")
+    public ResponseEntity<Void> deleteStation(@PathVariable Long stationId) {
+        stationService.delete(stationId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/wooteco/subway/ui/StationController.java
+++ b/src/main/java/wooteco/subway/ui/StationController.java
@@ -1,41 +1,46 @@
 package wooteco.subway.ui;
 
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 import wooteco.subway.dao.StationDao;
 import wooteco.subway.domain.Station;
 import wooteco.subway.dto.StationRequest;
 import wooteco.subway.dto.StationResponse;
-
-import java.net.URI;
-import java.util.List;
-import java.util.stream.Collectors;
+import wooteco.subway.service.StationService;
 
 @RestController
 public class StationController {
 
-    private final StationDao stationDao = new StationDao();
+    private final StationService stationService = new StationService(new StationDao());
 
     @PostMapping("/stations")
     public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {
-        Station station = new Station(stationRequest.getName());
-        Station newStation = stationDao.save(station);
-        StationResponse stationResponse = new StationResponse(newStation.getId(), newStation.getName());
-        return ResponseEntity.created(URI.create("/stations/" + newStation.getId())).body(stationResponse);
+        Station station = stationService.save(stationRequest.toStation());
+        return ResponseEntity.created(URI.create("/stations/" + station.getId())).body(StationResponse.from(station));
     }
 
     @GetMapping(value = "/stations", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<StationResponse>> showStations() {
-        List<Station> stations = stationDao.findAll();
-        List<StationResponse> stationResponses = stations.stream()
-                .map(it -> new StationResponse(it.getId(), it.getName()))
+        List<StationResponse> stationResponses = stationService.findAll()
+                .stream()
+                .map(StationResponse::from)
                 .collect(Collectors.toList());
+
         return ResponseEntity.ok().body(stationResponses);
     }
 
     @DeleteMapping("/stations/{id}")
     public ResponseEntity<Void> deleteStation(@PathVariable Long id) {
+        stationService.delete(id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/wooteco/subway/ui/StationController.java
+++ b/src/main/java/wooteco/subway/ui/StationController.java
@@ -15,17 +15,19 @@ import java.util.stream.Collectors;
 @RestController
 public class StationController {
 
+    private final StationDao stationDao = new StationDao();
+
     @PostMapping("/stations")
     public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {
         Station station = new Station(stationRequest.getName());
-        Station newStation = StationDao.save(station);
+        Station newStation = stationDao.save(station);
         StationResponse stationResponse = new StationResponse(newStation.getId(), newStation.getName());
         return ResponseEntity.created(URI.create("/stations/" + newStation.getId())).body(stationResponse);
     }
 
     @GetMapping(value = "/stations", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<StationResponse>> showStations() {
-        List<Station> stations = StationDao.findAll();
+        List<Station> stations = stationDao.findAll();
         List<StationResponse> stationResponses = stations.stream()
                 .map(it -> new StationResponse(it.getId(), it.getName()))
                 .collect(Collectors.toList());

--- a/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
+++ b/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
@@ -2,12 +2,14 @@ package wooteco.subway.ui;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import wooteco.subway.dto.SubwayErrorResponse;
+import wooteco.subway.exception.NotFoundException;
 
 @RestControllerAdvice
 public class SubwayControllerAdvice {
@@ -25,6 +27,11 @@ public class SubwayControllerAdvice {
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<Void> handleNoHandlerFoundException() {
         return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<SubwayErrorResponse> handleNotFoundException(NotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(SubwayErrorResponse.from(exception));
     }
 
     @ExceptionHandler(EmptyResultDataAccessException.class)

--- a/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
+++ b/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
@@ -3,6 +3,7 @@ package wooteco.subway.ui;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 import wooteco.subway.dto.SubwayErrorResponse;
 
 @RestControllerAdvice
@@ -11,5 +12,10 @@ public class SubwayControllerAdvice {
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<SubwayErrorResponse> handleBusinessException(RuntimeException exception) {
         return ResponseEntity.badRequest().body(SubwayErrorResponse.from(exception));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<Void> handleNoHandlerFoundExceptoin() {
+        return ResponseEntity.notFound().build();
     }
 }

--- a/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
+++ b/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
@@ -3,6 +3,7 @@ package wooteco.subway.ui;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
@@ -12,7 +13,12 @@ import wooteco.subway.dto.SubwayErrorResponse;
 public class SubwayControllerAdvice {
 
     @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<SubwayErrorResponse> handleBusinessException(RuntimeException exception) {
+    public ResponseEntity<SubwayErrorResponse> handleBusinessException(IllegalStateException exception) {
+        return ResponseEntity.badRequest().body(SubwayErrorResponse.from(exception));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<SubwayErrorResponse> handleValidException(MethodArgumentNotValidException exception) {
         return ResponseEntity.badRequest().body(SubwayErrorResponse.from(exception));
     }
 
@@ -32,7 +38,7 @@ public class SubwayControllerAdvice {
     }
 
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<Void> handleException() {
+    public ResponseEntity<Void> handleException(RuntimeException exception) {
         return ResponseEntity.internalServerError().build();
     }
 }

--- a/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
+++ b/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
@@ -1,0 +1,15 @@
+package wooteco.subway.ui;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import wooteco.subway.dto.SubwayErrorResponse;
+
+@RestControllerAdvice
+public class SubwayControllerAdvice {
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<SubwayErrorResponse> handleBusinessException(RuntimeException exception) {
+        return ResponseEntity.badRequest().body(SubwayErrorResponse.from(exception));
+    }
+}

--- a/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
+++ b/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
@@ -15,7 +15,12 @@ public class SubwayControllerAdvice {
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<Void> handleNoHandlerFoundExceptoin() {
+    public ResponseEntity<Void> handleNoHandlerFoundException() {
         return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Void> handleException() {
+        return ResponseEntity.internalServerError().build();
     }
 }

--- a/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
+++ b/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
@@ -1,5 +1,7 @@
 package wooteco.subway.ui;
 
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -17,6 +19,16 @@ public class SubwayControllerAdvice {
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<Void> handleNoHandlerFoundException() {
         return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler(EmptyResultDataAccessException.class)
+    public ResponseEntity<Void> handleNotFoundException() {
+        return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<Void> handleDataAcessException() {
+        return ResponseEntity.internalServerError().build();
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:maindb
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS STATION;
+DROP TABLE IF EXISTS LINE;
+
+CREATE TABLE STATION
+(
+    id   bigint auto_increment not null,
+    name varchar(255)          not null unique,
+    primary key (id)
+);
+
+CREATE TABLE LINE
+(
+    id    bigint auto_increment not null,
+    name  varchar(255)          not null unique,
+    color varchar(20)           not null,
+    primary key (id)
+);

--- a/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
@@ -1,0 +1,38 @@
+package wooteco.subway.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class LineAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    @DisplayName("노선을 추가한다.")
+    void save() {
+        //given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "신분당선");
+        params.put("color", "bg-red-600");
+
+        //when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.header("Location")).isNotBlank();
+    }
+}

--- a/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
@@ -12,14 +12,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import wooteco.subway.dao.LineDao;
+import wooteco.subway.dao.InmemoryLineDao;
 import wooteco.subway.dto.LineResponse;
 
 class LineAcceptanceTest extends AcceptanceTest {
 
     @AfterEach
     void afterEach() {
-        LineDao.getInstance().clear();
+        InmemoryLineDao.getInstance().clear();
     }
 
     @Test

--- a/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
@@ -35,4 +35,31 @@ class LineAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
         assertThat(response.header("Location")).isNotBlank();
     }
+
+    @Test
+    @DisplayName("기존에 존재하는 노선의 이름으로 노선을 생성한다.")
+    void createLinesWithExistNames() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "신분당선");
+        params.put("color", "bg-red-600");
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all();
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
 }

--- a/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import wooteco.subway.dto.LineResponse;
-import wooteco.subway.dto.StationResponse;
 
 class LineAcceptanceTest extends AcceptanceTest {
 
@@ -99,6 +98,34 @@ class LineAcceptanceTest extends AcceptanceTest {
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.jsonPath().getList(".", LineResponse.class)).hasSize(2);
+    }
 
+    @Test
+    @DisplayName("단일 노선을 조회한다.")
+    void findLine() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "신분당선");
+        params.put("color", "bg-red-600");
+        String location = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract()
+                .header("Location");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get(location)
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 }

--- a/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
@@ -7,20 +7,13 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import wooteco.subway.dao.InmemoryLineDao;
 import wooteco.subway.dto.LineResponse;
 
 class LineAcceptanceTest extends AcceptanceTest {
-
-    @AfterEach
-    void afterEach() {
-        InmemoryLineDao.getInstance().clear();
-    }
 
     @Test
     @DisplayName("노선을 추가한다.")
@@ -154,8 +147,8 @@ class LineAcceptanceTest extends AcceptanceTest {
 
         // when
         Map<String, String> params2 = new HashMap<>();
-        params.put("name", "분당선");
-        params.put("color", "bg-green-600");
+        params2.put("name", "분당선");
+        params2.put("color", "bg-green-600");
         ExtractableResponse<Response> response = RestAssured.given().log().all()
                 .body(params2)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
@@ -7,13 +7,20 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import wooteco.subway.dao.LineDao;
 import wooteco.subway.dto.LineResponse;
 
 class LineAcceptanceTest extends AcceptanceTest {
+
+    @AfterEach
+    void afterEach() {
+        LineDao.getInstance().clear();
+    }
 
     @Test
     @DisplayName("노선을 추가한다.")

--- a/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import wooteco.subway.dto.LineResponse;
+import wooteco.subway.dto.StationResponse;
 
 class LineAcceptanceTest extends AcceptanceTest {
 
@@ -61,5 +63,42 @@ class LineAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("전체 노선 목록을 조회한다.")
+    void findAllLines() {
+        //given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "신분당선");
+        params.put("color", "bg-red-600");
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all();
+
+        Map<String, String> params2 = new HashMap<>();
+        params2.put("name", "분당선");
+        params2.put("color", "bg-green-600");
+        RestAssured.given().log().all()
+                .body(params2)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all();
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .get("/lines")
+                .then().log().all()
+                .extract();
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.jsonPath().getList(".", LineResponse.class)).hasSize(2);
+
     }
 }

--- a/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
@@ -160,4 +160,31 @@ class LineAcceptanceTest extends AcceptanceTest {
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
+
+    @Test
+    @DisplayName("노선을 삭제한다.")
+    void deleteLine() {
+        //given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "신분당선");
+        params.put("color", "bg-red-600");
+        String location = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract()
+                .header("Location");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .delete(location)
+                .then().log().all()
+                .extract();
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
 }

--- a/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
@@ -128,4 +128,36 @@ class LineAcceptanceTest extends AcceptanceTest {
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
+
+    @Test
+    @DisplayName("노선을 수정한다.")
+    void updateLine() {
+        //given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "신분당선");
+        params.put("color", "bg-red-600");
+        String location = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract()
+                .header("Location");
+
+        // when
+        Map<String, String> params2 = new HashMap<>();
+        params.put("name", "분당선");
+        params.put("color", "bg-green-600");
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params2)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .put(location)
+                .then().log().all()
+                .extract();
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
 }

--- a/src/test/java/wooteco/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/StationAcceptanceTest.java
@@ -22,11 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("지하철역 관련 기능")
 public class StationAcceptanceTest extends AcceptanceTest {
 
-    @AfterEach
-    void afterEach() {
-        InmemoryStationDao.getInstance().clear();
-    }
-
     @DisplayName("지하철역을 생성한다.")
     @Test
     void createStation() {

--- a/src/test/java/wooteco/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/StationAcceptanceTest.java
@@ -8,8 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import wooteco.subway.acceptance.AcceptanceTest;
-import wooteco.subway.dao.StationDao;
+import wooteco.subway.dao.InmemoryStationDao;
 import wooteco.subway.dto.StationResponse;
 
 import java.util.Arrays;
@@ -25,7 +24,7 @@ public class StationAcceptanceTest extends AcceptanceTest {
 
     @AfterEach
     void afterEach() {
-        StationDao.getInstance().clear();
+        InmemoryStationDao.getInstance().clear();
     }
 
     @DisplayName("지하철역을 생성한다.")

--- a/src/test/java/wooteco/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/StationAcceptanceTest.java
@@ -3,11 +3,13 @@ package wooteco.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import wooteco.subway.acceptance.AcceptanceTest;
+import wooteco.subway.dao.StationDao;
 import wooteco.subway.dto.StationResponse;
 
 import java.util.Arrays;
@@ -20,6 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관련 기능")
 public class StationAcceptanceTest extends AcceptanceTest {
+
+    @AfterEach
+    void afterEach() {
+        StationDao.getInstance().clear();
+    }
+
     @DisplayName("지하철역을 생성한다.")
     @Test
     void createStation() {

--- a/src/test/java/wooteco/subway/dao/InmemoryLineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/InmemoryLineDaoTest.java
@@ -52,6 +52,14 @@ class InmemoryLineDaoTest {
     }
 
     @Test
+    @DisplayName("id에 해당하는 Line이 존재하는지 확인할 수 있다.")
+    void existById() {
+        Line line = inmemoryLineDao.save(new Line("신분당선", "bg-red-600"));
+
+        assertThat(inmemoryLineDao.existById(line.getId())).isNotNull();
+    }
+
+    @Test
     @DisplayName("Line을 수정할 수 있다.")
     void update() {
         Line line = inmemoryLineDao.save(new Line("신분당선", "bg-red-600"));

--- a/src/test/java/wooteco/subway/dao/InmemoryLineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/InmemoryLineDaoTest.java
@@ -7,20 +7,20 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import wooteco.subway.domain.Line;
 
-class LineDaoTest {
+class InmemoryLineDaoTest {
 
-    private final LineDao lineDao = LineDao.getInstance();
+    private final InmemoryLineDao inmemoryLineDao = InmemoryLineDao.getInstance();
 
     @AfterEach
     void afterEach() {
-        lineDao.clear();
+        inmemoryLineDao.clear();
     }
 
     @Test
     @DisplayName("Line을 등록할 수 있다.")
     void save() {
         Line line = new Line("신분당선", "bg-red-600");
-        Line savedLine = lineDao.save(line);
+        Line savedLine = inmemoryLineDao.save(line);
 
         assertThat(savedLine.getId()).isNotNull();
     }
@@ -28,8 +28,8 @@ class LineDaoTest {
     @Test
     @DisplayName("Line을 id로 조회할 수 있다.")
     void findById() {
-        Line line = lineDao.save(new Line("신분당선", "bg-red-600"));
-        Line findLine = lineDao.findById(line.getId());
+        Line line = inmemoryLineDao.save(new Line("신분당선", "bg-red-600"));
+        Line findLine = inmemoryLineDao.findById(line.getId());
 
         assertThat(findLine).isEqualTo(line);
     }
@@ -37,17 +37,17 @@ class LineDaoTest {
     @Test
     @DisplayName("Line 전체 조회할 수 있다.")
     void findAll() {
-        lineDao.save(new Line("신분당선", "bg-red-600"));
-        lineDao.save(new Line("분당선", "bg-green-600"));
+        inmemoryLineDao.save(new Line("신분당선", "bg-red-600"));
+        inmemoryLineDao.save(new Line("분당선", "bg-green-600"));
 
-        assertThat(lineDao.findAll()).hasSize(2);
+        assertThat(inmemoryLineDao.findAll()).hasSize(2);
     }
 
     @Test
     @DisplayName("Line을 수정할 수 있다.")
     void update() {
-        Line line = lineDao.save(new Line("신분당선", "bg-red-600"));
-        int result = lineDao.update(new Line(line.getId(), "분당선", line.getColor()));
+        Line line = inmemoryLineDao.save(new Line("신분당선", "bg-red-600"));
+        int result = inmemoryLineDao.update(new Line(line.getId(), "분당선", line.getColor()));
 
         assertThat(result).isEqualTo(1);
     }
@@ -55,8 +55,8 @@ class LineDaoTest {
     @Test
     @DisplayName("Line을 삭제할 수 있다.")
     void delete() {
-        Line line = lineDao.save(new Line("신분당선", "bg-red-600"));
-        int result = lineDao.delete(line.getId());
+        Line line = inmemoryLineDao.save(new Line("신분당선", "bg-red-600"));
+        int result = inmemoryLineDao.delete(line.getId());
 
         assertThat(result).isEqualTo(1);
     }
@@ -64,8 +64,8 @@ class LineDaoTest {
     @Test
     @DisplayName("Line 이름이 존재하는지 확인할 수 있다.")
     void existByName() {
-        lineDao.save(new Line("신분당선", "bg-red-600"));
+        inmemoryLineDao.save(new Line("신분당선", "bg-red-600"));
 
-        assertThat(lineDao.existByName("신분당선")).isTrue();
+        assertThat(inmemoryLineDao.existByName("신분당선")).isTrue();
     }
 }

--- a/src/test/java/wooteco/subway/dao/InmemoryLineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/InmemoryLineDaoTest.java
@@ -44,6 +44,14 @@ class InmemoryLineDaoTest {
     }
 
     @Test
+    @DisplayName("Line 이름이 존재하는지 확인할 수 있다.")
+    void existByName() {
+        inmemoryLineDao.save(new Line("신분당선", "bg-red-600"));
+
+        assertThat(inmemoryLineDao.existByName("신분당선")).isTrue();
+    }
+
+    @Test
     @DisplayName("Line을 수정할 수 있다.")
     void update() {
         Line line = inmemoryLineDao.save(new Line("신분당선", "bg-red-600"));
@@ -59,13 +67,5 @@ class InmemoryLineDaoTest {
         int result = inmemoryLineDao.delete(line.getId());
 
         assertThat(result).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("Line 이름이 존재하는지 확인할 수 있다.")
-    void existByName() {
-        inmemoryLineDao.save(new Line("신분당선", "bg-red-600"));
-
-        assertThat(inmemoryLineDao.existByName("신분당선")).isTrue();
     }
 }

--- a/src/test/java/wooteco/subway/dao/InmemoryStationDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/InmemoryStationDaoTest.java
@@ -7,20 +7,20 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import wooteco.subway.domain.Station;
 
-class StationDaoTest {
+class InmemoryStationDaoTest {
 
-    private final StationDao stationDao = StationDao.getInstance();
+    private final InmemoryStationDao inmemoryStationDao = InmemoryStationDao.getInstance();
 
     @AfterEach
     void afterEach() {
-        stationDao.clear();
+        inmemoryStationDao.clear();
     }
 
     @Test
     @DisplayName("Station을 저장할 수 있다.")
     void save() {
         Station station = new Station("오리");
-        Station savedStation = stationDao.save(station);
+        Station savedStation = inmemoryStationDao.save(station);
 
         assertThat(savedStation.getId()).isNotNull();
     }
@@ -28,27 +28,27 @@ class StationDaoTest {
     @Test
     @DisplayName("모든 Station을 조회할 수 있다.")
     void findAll() {
-        stationDao.save(new Station("오리"));
-        stationDao.save(new Station("배카라"));
+        inmemoryStationDao.save(new Station("오리"));
+        inmemoryStationDao.save(new Station("배카라"));
 
-        assertThat(stationDao.findAll()).hasSize(2);
+        assertThat(inmemoryStationDao.findAll()).hasSize(2);
     }
 
     @Test
     @DisplayName("Station을 삭제할 수 있다.")
     void delete() {
-        Station station = stationDao.save(new Station("오리"));
+        Station station = inmemoryStationDao.save(new Station("오리"));
         Long stationId = station.getId();
 
-        assertThat(stationDao.delete(stationId)).isEqualTo(1);
+        assertThat(inmemoryStationDao.delete(stationId)).isEqualTo(1);
     }
 
     @Test
     @DisplayName("Station 이름이 존재하는지 확인할 수 있다.")
     void existByName() {
         String name = "오리";
-        stationDao.save(new Station(name));
+        inmemoryStationDao.save(new Station(name));
 
-        assertThat(stationDao.existByName(name)).isTrue();
+        assertThat(inmemoryStationDao.existByName(name)).isTrue();
     }
 }

--- a/src/test/java/wooteco/subway/dao/InmemoryStationDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/InmemoryStationDaoTest.java
@@ -51,4 +51,12 @@ class InmemoryStationDaoTest {
 
         assertThat(inmemoryStationDao.existByName(name)).isTrue();
     }
+
+    @Test
+    @DisplayName("id를 가진 Station이 존재하는지 확인할 수 있다.")
+    void existById() {
+        Station station = inmemoryStationDao.save(new Station("오리"));
+
+        assertThat(inmemoryStationDao.existById(station.getId())).isTrue();
+    }
 }

--- a/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
@@ -50,4 +50,12 @@ class JdbcLineDaoTest {
 
         assertThat(lineDao.findAll()).hasSize(2);
     }
+
+    @Test
+    @DisplayName("Line 이름이 존재하는지 확인할 수 있다.")
+    void existByName() {
+        lineDao.save(new Line("신분당선", "bg-red-600"));
+
+        assertThat(lineDao.existByName("신분당선")).isTrue();
+    }
 }

--- a/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
@@ -58,4 +58,13 @@ class JdbcLineDaoTest {
 
         assertThat(lineDao.existByName("신분당선")).isTrue();
     }
+
+    @Test
+    @DisplayName("Line을 수정할 수 있다.")
+    void update() {
+        Line line = lineDao.save(new Line("신분당선", "bg-red-600"));
+        int result = lineDao.update(new Line(line.getId(), "분당선", line.getColor()));
+
+        assertThat(result).isEqualTo(1);
+    }
 }

--- a/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
@@ -32,4 +32,13 @@ class JdbcLineDaoTest {
 
         assertThat(savedLine.getId()).isNotNull();
     }
+
+    @Test
+    @DisplayName("Line을 id로 조회할 수 있다.")
+    void findById() {
+        Line line = lineDao.save(new Line("신분당선", "bg-red-600"));
+        Line findLine = lineDao.findById(line.getId());
+
+        assertThat(findLine).isEqualTo(line);
+    }
 }

--- a/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
@@ -1,7 +1,6 @@
 package wooteco.subway.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -57,6 +56,14 @@ class JdbcLineDaoTest {
         lineDao.save(new Line("신분당선", "bg-red-600"));
 
         assertThat(lineDao.existByName("신분당선")).isTrue();
+    }
+
+    @Test
+    @DisplayName("id에 해당하는 Line이 존재하는지 확인할 수 있다.")
+    void existById() {
+        Line line = lineDao.save(new Line("신분당선", "bg-red-600"));
+
+        assertThat(lineDao.existById(line.getId())).isNotNull();
     }
 
     @Test

--- a/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
@@ -41,4 +41,13 @@ class JdbcLineDaoTest {
 
         assertThat(findLine).isEqualTo(line);
     }
+
+    @Test
+    @DisplayName("Line 전체 조회할 수 있다.")
+    void findAll() {
+        lineDao.save(new Line("신분당선", "bg-red-600"));
+        lineDao.save(new Line("분당선", "bg-green-600"));
+
+        assertThat(lineDao.findAll()).hasSize(2);
+    }
 }

--- a/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
@@ -1,0 +1,35 @@
+package wooteco.subway.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import wooteco.subway.domain.Line;
+
+@JdbcTest
+class JdbcLineDaoTest {
+
+    private LineDao lineDao;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        lineDao = new JdbcLineDao(jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("Line을 등록할 수 있다.")
+    void save() {
+        Line line = new Line("신분당선", "bg-red-600");
+        Line savedLine = lineDao.save(line);
+
+        assertThat(savedLine.getId()).isNotNull();
+    }
+}

--- a/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
@@ -67,4 +67,13 @@ class JdbcLineDaoTest {
 
         assertThat(result).isEqualTo(1);
     }
+
+    @Test
+    @DisplayName("Line을 삭제할 수 있다.")
+    void delete() {
+        Line line = lineDao.save(new Line("신분당선", "bg-red-600"));
+        int result = lineDao.delete(line.getId());
+
+        assertThat(result).isEqualTo(1);
+    }
 }

--- a/src/test/java/wooteco/subway/dao/JdbcStationDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcStationDaoTest.java
@@ -51,6 +51,14 @@ class JdbcStationDaoTest {
     }
 
     @Test
+    @DisplayName("id를 가진 Station이 존재하는지 확인할 수 있다.")
+    void existById() {
+        Station station = stationDao.save(new Station("오리"));
+
+        assertThat(stationDao.existById(station.getId())).isTrue();
+    }
+
+    @Test
     @DisplayName("Station을 삭제할 수 있다.")
     void delete() {
         Station station = stationDao.save(new Station("오리"));

--- a/src/test/java/wooteco/subway/dao/JdbcStationDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcStationDaoTest.java
@@ -42,6 +42,15 @@ class JdbcStationDaoTest {
     }
 
     @Test
+    @DisplayName("Station 이름이 존재하는지 확인할 수 있다.")
+    void existByName() {
+        String name = "배카라";
+        stationDao.save(new Station(name));
+
+        assertThat(stationDao.existByName(name)).isTrue();
+    }
+
+    @Test
     @DisplayName("Station을 삭제할 수 있다.")
     void delete() {
         Station station = stationDao.save(new Station("오리"));

--- a/src/test/java/wooteco/subway/dao/JdbcStationDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcStationDaoTest.java
@@ -1,7 +1,6 @@
 package wooteco.subway.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,5 +30,14 @@ class JdbcStationDaoTest {
         Station savedStation = stationDao.save(station);
 
         assertThat(savedStation.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("모든 Station을 조회할 수 있다.")
+    void findAll() {
+        stationDao.save(new Station("오리"));
+        stationDao.save(new Station("배카라"));
+
+        assertThat(stationDao.findAll()).hasSize(2);
     }
 }

--- a/src/test/java/wooteco/subway/dao/JdbcStationDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcStationDaoTest.java
@@ -40,4 +40,13 @@ class JdbcStationDaoTest {
 
         assertThat(stationDao.findAll()).hasSize(2);
     }
+
+    @Test
+    @DisplayName("Station을 삭제할 수 있다.")
+    void delete() {
+        Station station = stationDao.save(new Station("오리"));
+        Long stationId = station.getId();
+
+        assertThat(stationDao.delete(stationId)).isEqualTo(1);
+    }
 }

--- a/src/test/java/wooteco/subway/dao/JdbcStationDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcStationDaoTest.java
@@ -1,0 +1,35 @@
+package wooteco.subway.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import wooteco.subway.domain.Station;
+
+@JdbcTest
+class JdbcStationDaoTest {
+
+    private StationDao stationDao;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        stationDao = new JdbcStationDao(jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("Station을 저장할 수 있다.")
+    void save() {
+        Station station = new Station("배카라");
+        Station savedStation = stationDao.save(station);
+
+        assertThat(savedStation.getId()).isNotNull();
+    }
+}

--- a/src/test/java/wooteco/subway/dao/LineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/LineDaoTest.java
@@ -53,7 +53,7 @@ class LineDaoTest {
     }
 
     @Test
-    @DisplayName("Line을 삭할 수 있다.")
+    @DisplayName("Line을 삭제할 수 있다.")
     void delete() {
         Line line = lineDao.save(new Line("신분당선", "bg-red-600"));
         int result = lineDao.delete(line.getId());

--- a/src/test/java/wooteco/subway/dao/LineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/LineDaoTest.java
@@ -1,0 +1,27 @@
+package wooteco.subway.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import wooteco.subway.domain.Line;
+
+class LineDaoTest {
+
+    private LineDao lineDao;
+
+    @BeforeEach
+    void setUp() {
+        lineDao = new LineDao();
+    }
+
+    @Test
+    @DisplayName("Line을 등록할 수 있다.")
+    void save() {
+        Line line = new Line("신분당선", "bg-red-600");
+        Line savedLine = lineDao.save(line);
+
+        assertThat(savedLine.getId()).isNotNull();
+    }
+}

--- a/src/test/java/wooteco/subway/dao/LineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/LineDaoTest.java
@@ -42,4 +42,13 @@ class LineDaoTest {
 
         assertThat(lineDao.findAll()).hasSize(2);
     }
+
+    @Test
+    @DisplayName("Line을 수정할 수 있다.")
+    void update() {
+        Line line = lineDao.save(new Line("신분당선", "bg-red-600"));
+        int result = lineDao.update(new Line(line.getId(), "분당선", line.getColor()));
+
+        assertThat(result).isEqualTo(1);
+    }
 }

--- a/src/test/java/wooteco/subway/dao/LineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/LineDaoTest.java
@@ -24,4 +24,13 @@ class LineDaoTest {
 
         assertThat(savedLine.getId()).isNotNull();
     }
+
+    @Test
+    @DisplayName("Line을 id로 조회할 수 있다.")
+    void findById() {
+        Line line = lineDao.save(new Line("신분당선", "bg-red-600"));
+        Line findLine = lineDao.findById(line.getId());
+
+        assertThat(findLine).isEqualTo(line);
+    }
 }

--- a/src/test/java/wooteco/subway/dao/LineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/LineDaoTest.java
@@ -2,18 +2,18 @@ package wooteco.subway.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import wooteco.subway.domain.Line;
 
 class LineDaoTest {
 
-    private LineDao lineDao;
+    private final LineDao lineDao = LineDao.getInstance();
 
-    @BeforeEach
-    void setUp() {
-        lineDao = new LineDao();
+    @AfterEach
+    void afterEach() {
+        lineDao.clear();
     }
 
     @Test

--- a/src/test/java/wooteco/subway/dao/LineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/LineDaoTest.java
@@ -33,4 +33,13 @@ class LineDaoTest {
 
         assertThat(findLine).isEqualTo(line);
     }
+
+    @Test
+    @DisplayName("Line 전체 조회할 수 있다.")
+    void findAll() {
+        lineDao.save(new Line("신분당선", "bg-red-600"));
+        lineDao.save(new Line("분당선", "bg-green-600"));
+
+        assertThat(lineDao.findAll()).hasSize(2);
+    }
 }

--- a/src/test/java/wooteco/subway/dao/LineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/LineDaoTest.java
@@ -51,4 +51,13 @@ class LineDaoTest {
 
         assertThat(result).isEqualTo(1);
     }
+
+    @Test
+    @DisplayName("Line을 삭할 수 있다.")
+    void delete() {
+        Line line = lineDao.save(new Line("신분당선", "bg-red-600"));
+        int result = lineDao.delete(line.getId());
+
+        assertThat(result).isEqualTo(1);
+    }
 }

--- a/src/test/java/wooteco/subway/dao/LineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/LineDaoTest.java
@@ -60,4 +60,12 @@ class LineDaoTest {
 
         assertThat(result).isEqualTo(1);
     }
+
+    @Test
+    @DisplayName("Line 이름이 존재하는지 확인할 수 있다.")
+    void existByName() {
+        lineDao.save(new Line("신분당선", "bg-red-600"));
+
+        assertThat(lineDao.existByName("신분당선")).isTrue();
+    }
 }

--- a/src/test/java/wooteco/subway/dao/StationDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/StationDaoTest.java
@@ -1,19 +1,26 @@
 package wooteco.subway.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import wooteco.subway.domain.Station;
 
 class StationDaoTest {
 
+    private StationDao stationDao;
+
+    @BeforeEach
+    void setUp() {
+        stationDao = new StationDao();
+    }
+
     @Test
     @DisplayName("Station을 저장할 수 있다.")
     void save() {
         Station station = new Station("오리");
-        Station savedStation = StationDao.save(station);
+        Station savedStation = stationDao.save(station);
 
         assertThat(savedStation.getId()).isNotNull();
     }
@@ -21,9 +28,18 @@ class StationDaoTest {
     @Test
     @DisplayName("모든 Station을 조회할 수 있다.")
     void findAll() {
-        StationDao.save(new Station("오리"));
-        StationDao.save(new Station("배카라"));
+        stationDao.save(new Station("오리"));
+        stationDao.save(new Station("배카라"));
 
-        assertThat(StationDao.findAll()).hasSize(2);
+        assertThat(stationDao.findAll()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Station을 삭제할 수 있다.")
+    void delete() {
+        Station station = stationDao.save(new Station("오리"));
+        Long stationId = station.getId();
+
+        assertThat(stationDao.delete(stationId)).isEqualTo(1);
     }
 }

--- a/src/test/java/wooteco/subway/dao/StationDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/StationDaoTest.java
@@ -14,6 +14,16 @@ class StationDaoTest {
     void save() {
         Station station = new Station("오리");
         Station savedStation = StationDao.save(station);
+
         assertThat(savedStation.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("모든 Station을 조회할 수 있다.")
+    void findAll() {
+        StationDao.save(new Station("오리"));
+        StationDao.save(new Station("배카라"));
+
+        assertThat(StationDao.findAll()).hasSize(2);
     }
 }

--- a/src/test/java/wooteco/subway/dao/StationDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/StationDaoTest.java
@@ -2,18 +2,18 @@ package wooteco.subway.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import wooteco.subway.domain.Station;
 
 class StationDaoTest {
 
-    private StationDao stationDao;
+    private final StationDao stationDao = StationDao.getInstance();
 
-    @BeforeEach
-    void setUp() {
-        stationDao = new StationDao();
+    @AfterEach
+    void afterEach() {
+        stationDao.clear();
     }
 
     @Test

--- a/src/test/java/wooteco/subway/dao/StationDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/StationDaoTest.java
@@ -1,0 +1,19 @@
+package wooteco.subway.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import wooteco.subway.domain.Station;
+
+class StationDaoTest {
+
+    @Test
+    @DisplayName("Station을 저장할 수 있다.")
+    void save() {
+        Station station = new Station("오리");
+        Station savedStation = StationDao.save(station);
+        assertThat(savedStation.getId()).isNotNull();
+    }
+}

--- a/src/test/java/wooteco/subway/dao/StationDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/StationDaoTest.java
@@ -42,4 +42,13 @@ class StationDaoTest {
 
         assertThat(stationDao.delete(stationId)).isEqualTo(1);
     }
+
+    @Test
+    @DisplayName("Station 이름이 존재하는지 확인할 수 있다.")
+    void existByName() {
+        String name = "오리";
+        stationDao.save(new Station(name));
+
+        assertThat(stationDao.existByName(name)).isTrue();
+    }
 }

--- a/src/test/java/wooteco/subway/service/LineServiceTest.java
+++ b/src/test/java/wooteco/subway/service/LineServiceTest.java
@@ -3,7 +3,6 @@ package wooteco.subway.service;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import wooteco.subway.dao.LineDao;

--- a/src/test/java/wooteco/subway/service/LineServiceTest.java
+++ b/src/test/java/wooteco/subway/service/LineServiceTest.java
@@ -2,6 +2,7 @@ package wooteco.subway.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,13 +11,12 @@ import wooteco.subway.domain.Line;
 
 class LineServiceTest {
 
-    private LineDao lineDao;
-    private LineService lineService;
+    private final LineDao lineDao = LineDao.getInstance();
+    private final LineService lineService = new LineService(lineDao);
 
-    @BeforeEach
-    void setUp() {
-        lineDao = new LineDao();
-        lineService = new LineService(lineDao);
+    @AfterEach
+    void afterEach() {
+        lineDao.clear();
     }
 
     @Test

--- a/src/test/java/wooteco/subway/service/LineServiceTest.java
+++ b/src/test/java/wooteco/subway/service/LineServiceTest.java
@@ -1,0 +1,30 @@
+package wooteco.subway.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import wooteco.subway.dao.LineDao;
+import wooteco.subway.domain.Line;
+
+class LineServiceTest {
+
+    private LineDao lineDao;
+    private LineService lineService;
+
+    @BeforeEach
+    void setUp() {
+        lineDao = new LineDao();
+        lineService = new LineService(lineDao);
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 노선의 이름이 있을 때 예외가 발생한다.")
+    void saveExceptionByExistName() {
+        lineDao.save(new Line("신분당선", "bg-red-600"));
+        assertThatThrownBy(() -> lineService.save(new Line("신분당선", "bg-green-600")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 존재하는 노선 이름입니다.");
+    }
+}

--- a/src/test/java/wooteco/subway/service/LineServiceTest.java
+++ b/src/test/java/wooteco/subway/service/LineServiceTest.java
@@ -5,23 +5,23 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import wooteco.subway.dao.LineDao;
+import wooteco.subway.dao.InmemoryLineDao;
 import wooteco.subway.domain.Line;
 
 class LineServiceTest {
 
-    private final LineDao lineDao = LineDao.getInstance();
-    private final LineService lineService = new LineService(lineDao);
+    private final InmemoryLineDao inmemoryLineDao = InmemoryLineDao.getInstance();
+    private final LineService lineService = new LineService(inmemoryLineDao);
 
     @AfterEach
     void afterEach() {
-        lineDao.clear();
+        inmemoryLineDao.clear();
     }
 
     @Test
     @DisplayName("이미 존재하는 노선의 이름이 있을 때 예외가 발생한다.")
     void saveExceptionByExistName() {
-        lineDao.save(new Line("신분당선", "bg-red-600"));
+        inmemoryLineDao.save(new Line("신분당선", "bg-red-600"));
         assertThatThrownBy(() -> lineService.save(new Line("신분당선", "bg-green-600")))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("이미 존재하는 노선 이름입니다.");

--- a/src/test/java/wooteco/subway/service/LineServiceTest.java
+++ b/src/test/java/wooteco/subway/service/LineServiceTest.java
@@ -35,4 +35,12 @@ class LineServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage("존재하지 않는 Line입니다.");
     }
+
+    @Test
+    @DisplayName("존재하지 않는 id로 delete하려할 경우 예외가 발생한다.")
+    void deleteExceptionByNotFoundLine() {
+        assertThatThrownBy(() -> lineService.delete(1L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 Line입니다.");
+    }
 }

--- a/src/test/java/wooteco/subway/service/LineServiceTest.java
+++ b/src/test/java/wooteco/subway/service/LineServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import wooteco.subway.dao.InmemoryLineDao;
 import wooteco.subway.domain.Line;
+import wooteco.subway.exception.NotFoundException;
 
 class LineServiceTest {
 
@@ -25,5 +26,13 @@ class LineServiceTest {
         assertThatThrownBy(() -> lineService.save(new Line("신분당선", "bg-green-600")))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("이미 존재하는 노선 이름입니다.");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 id로 update하려할 경우 예외가 발생한다.")
+    void updateExceptionByNotFoundLine() {
+        assertThatThrownBy(() -> lineService.update(new Line(1L, "신분당선", "bg-green-600")))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 Line입니다.");
     }
 }

--- a/src/test/java/wooteco/subway/service/StationServiceTest.java
+++ b/src/test/java/wooteco/subway/service/StationServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import wooteco.subway.dao.InmemoryStationDao;
 import wooteco.subway.domain.Station;
+import wooteco.subway.exception.NotFoundException;
 
 class StationServiceTest {
 
@@ -25,5 +26,13 @@ class StationServiceTest {
         assertThatThrownBy(() -> stationService.save(new Station("오리")))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("이미 존재하는 역 이름입니다.");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 id로 delete하려할 경우 예외가 발생한다.")
+    void deleteExceptionByNotFoundLine() {
+        assertThatThrownBy(() -> stationService.delete(1L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 Station입니다.");
     }
 }

--- a/src/test/java/wooteco/subway/service/StationServiceTest.java
+++ b/src/test/java/wooteco/subway/service/StationServiceTest.java
@@ -1,0 +1,7 @@
+package wooteco.subway.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StationServiceTest {
+
+}

--- a/src/test/java/wooteco/subway/service/StationServiceTest.java
+++ b/src/test/java/wooteco/subway/service/StationServiceTest.java
@@ -1,7 +1,30 @@
 package wooteco.subway.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import wooteco.subway.dao.StationDao;
+import wooteco.subway.domain.Station;
 
 class StationServiceTest {
 
+    private StationDao stationDao;
+    private StationService stationService;
+
+    @BeforeEach
+    void setUp() {
+        stationDao = new StationDao();
+        stationService = new StationService(stationDao);
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 역 이름이 있을 때 예외가 발생한다.")
+    void saveExceptionByDuplicatedName() {
+        stationDao.save(new Station("오리"));
+        assertThatThrownBy(() -> stationService.save(new Station("오리")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 존재하는 역 이름입니다.");
+    }
 }

--- a/src/test/java/wooteco/subway/service/StationServiceTest.java
+++ b/src/test/java/wooteco/subway/service/StationServiceTest.java
@@ -2,6 +2,7 @@ package wooteco.subway.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,13 +11,12 @@ import wooteco.subway.domain.Station;
 
 class StationServiceTest {
 
-    private StationDao stationDao;
-    private StationService stationService;
+    private final StationDao stationDao = StationDao.getInstance();
+    private final StationService stationService = new StationService(stationDao);
 
-    @BeforeEach
-    void setUp() {
-        stationDao = new StationDao();
-        stationService = new StationService(stationDao);
+    @AfterEach
+    void afterEach() {
+        stationDao.clear();
     }
 
     @Test

--- a/src/test/java/wooteco/subway/service/StationServiceTest.java
+++ b/src/test/java/wooteco/subway/service/StationServiceTest.java
@@ -3,26 +3,25 @@ package wooteco.subway.service;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import wooteco.subway.dao.StationDao;
+import wooteco.subway.dao.InmemoryStationDao;
 import wooteco.subway.domain.Station;
 
 class StationServiceTest {
 
-    private final StationDao stationDao = StationDao.getInstance();
-    private final StationService stationService = new StationService(stationDao);
+    private final InmemoryStationDao inmemoryStationDao = InmemoryStationDao.getInstance();
+    private final StationService stationService = new StationService(inmemoryStationDao);
 
     @AfterEach
     void afterEach() {
-        stationDao.clear();
+        inmemoryStationDao.clear();
     }
 
     @Test
     @DisplayName("이미 존재하는 역 이름이 있을 때 예외가 발생한다.")
     void saveExceptionByDuplicatedName() {
-        stationDao.save(new Station("오리"));
+        inmemoryStationDao.save(new Station("오리"));
         assertThatThrownBy(() -> stationService.save(new Station("오리")))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("이미 존재하는 역 이름입니다.");

--- a/src/test/java/wooteco/subway/ui/SubwayControllerAdviceTest.java
+++ b/src/test/java/wooteco/subway/ui/SubwayControllerAdviceTest.java
@@ -1,12 +1,15 @@
 package wooteco.subway.ui;
 
 import io.restassured.RestAssured;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class SubwayControllerAdviceTest {
@@ -27,5 +30,21 @@ class SubwayControllerAdviceTest {
                 .post("/test/not_found")
                 .then().log().all()
                 .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    @DisplayName("invalid request dto 요청")
+    void invalidDto() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", null);
+        params.put("color", "bg-red-600");
+
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/src/test/java/wooteco/subway/ui/SubwayControllerAdviceTest.java
+++ b/src/test/java/wooteco/subway/ui/SubwayControllerAdviceTest.java
@@ -1,0 +1,31 @@
+package wooteco.subway.ui;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SubwayControllerAdviceTest {
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("없는 경로 api 요청")
+    void notFoundUrl() {
+        RestAssured.given().log().all()
+                .when()
+                .post("/test/not_found")
+                .then().log().all()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS STATION;
+DROP TABLE IF EXISTS LINE;
+
+CREATE TABLE STATION
+(
+    id   bigint auto_increment not null,
+    name varchar(255)          not null unique,
+    primary key (id)
+);
+
+CREATE TABLE LINE
+(
+    id    bigint auto_increment not null,
+    name  varchar(255)          not null unique,
+    color varchar(20)           not null,
+    primary key (id)
+);


### PR DESCRIPTION
안녕하세요 닉 :)

제일 처음봤던 테코톡이 닉 테코톡이었는데 연예인을 보는 것 같은 느낌이네요 😄 
이번 미션은 지난번 미션을 진행하면서 스프링에 대해서 알게된 것들을 정리하면서 진행할 수 있었던 미션이었던 것 같아요. pr 기간이 짧아서 더 고려해보고싶었던 내용은 공부를 하면서 더 채워나가겠습니다 🔥 

개발하면서 느꼈던 내용 comment 더해서 풀리퀘 드려요 😄

### 1. delete, update id값 검증
- update는 조금 다르긴 하지만 delete와 update 모두 `@PathVariable`에서 온 id값을 가지고 쿼리를 날리게 되는데요. dao에서는 각각 하나의 쿼리를 날리게되기는 하지만 `Service`에서 id값에 대한 검증을 또 해줘야하느냐에 대한 고민이 있었어요. 
- 두가지 방법에 대해서 고려를 했는데요.
```java
class StationService

public void delete(final Long stationId) {
    if (stationDao.delete(stationId) != 1) {
        throw new IllegalStateException("삭제되지 않았습니다.");
    }
}

@Transactional
public void delete(final Long stationId) {
    if (stationDao.existById(stationId)) {
        throw new IllegalStateException("존재하지 않는 station입니다.");
    }
    stationDao.delete(stationId);
}
```
- Dao에서는 delete하는 쿼리에 대해서 try-catch하기보다는 delete 쿼리를 실행하는 역할만 하고, delete가 되었는지 되지 않았는지에 대해서는 반환으로 쿼리 실행수를 주기 때문에 Dao에서의 검증은 고려하지 않았습니다.
- 그래서 위의 두가지를 고려했는데요. 현재는 아래의 방식을 사용하고 있습니다.
- 현재는 아래의 방식을 사용하고 있지만 쿼리가 두번 나가고, delete 쿼리에 대해서 반환이 1인지 확인하기만 한다면 굳이 두번의 쿼리를 발생시키지 않을 수 있다고 생각하는데요. `jdbcTemplate.update()`에서 반환되는 실행 쿼리의 수만으로 검증하는것에 대해서 어디까지 신뢰를 해야하는지 의문이 드는 것 같아요.

- 입력된 id에 대해서 일반 CUD 쿼리를 진행하기 전에 값이 존재하는지 여부에 대한 검증을 어떻게 해야하느냐에 대해서 닉은 어떻게 생각하시는지 궁금합니다. 🤔 

### 2. controller 네이밍
- 사실 조금 복잡한 도메인이 왔을 때는 어떻게 달라질지는 모르지만 CRUD만 있는 현재 상황에서 `controller`에 대한 네임을 어떻게 해야할 지 고민이에요. (`service`까지)
- `dao`에서는 각각의 쿼리에 따라 `save()`, `findAll()`, `findBy~()`, `delete()`와 같은 명칭을 사용하고 있는데 controller에서도 또한 사실 그대로 CRUD를 하고있는 상황이라 네이밍을 그대로 사용하는게 과연 맞는건가에 대한 생각이 들었던 것 같아요.
- 단순히 계층의 역할 자체가 다르기는 하지만, 그대로 네이밍을 쓰기보다는 가장 앞단에 있는 계층인만큼 의미를 조금 부여해야한다고 생각했기 때문이에요. 기존에 초기 프로젝트에서 제공하는 controller에서처럼요.
- 닉은 dao의 기능을 그대로 사용하는 단순한 기능일 때 controller, service 등에 대햇 어떤 식으로 네이밍을 진행하시는지 궁금합니다 :)

감사합니다 🙇‍♂️